### PR TITLE
fix: tmux console refresh reliability

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -89,7 +89,7 @@ pub const RENDER_THROTTLE_MS: u64 = 36;
 pub const PERF_STATS_REFRESH_MS: u64 = 500;
 
 /// Delay after tmux send-keys in milliseconds (allows command output to appear)
-pub const TMUX_SEND_DELAY_MS: u64 = 300;
+pub const TMUX_SEND_DELAY_MS: u64 = 1000;
 
 /// Fixed sleep duration in seconds for the sleep tool
 pub const SLEEP_DURATION_SECS: u64 = 1;

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -798,11 +798,14 @@ impl App {
 
             let panel = crate::core::panels::get_panel(ctx.context_type);
 
-            // Timer-based interval refresh: only for fixed panels (P0-P7) and the
-            // currently selected panel.  Dynamic panels that aren't selected don't
-            // need continuous background polling — they'll refresh when selected or
-            // when a watcher event marks them deprecated.
-            let interval_eligible = ctx.context_type.is_fixed() || i == self.state.selected_context;
+            // Timer-based interval refresh: for fixed panels (P0-P7), the currently
+            // selected panel, AND tmux panels (always, since capture is lightweight).
+            // Other dynamic panels that aren't selected don't need continuous background
+            // polling — they'll refresh when selected or when a watcher event marks them
+            // deprecated.
+            let interval_eligible = ctx.context_type.is_fixed()
+                || i == self.state.selected_context
+                || ctx.context_type == ContextType::Tmux;
             let interval_elapsed = if interval_eligible {
                 panel.cache_refresh_interval_ms()
                     .map(|interval| current_ms.saturating_sub(ctx.last_refresh_ms) >= interval)

--- a/src/modules/tmux/mod.rs
+++ b/src/modules/tmux/mod.rs
@@ -84,9 +84,9 @@ impl Module for TmuxModule {
             },
             ToolDefinition {
                 id: "console_sleep".to_string(),
-                name: "Console Sleep".to_string(),
-                short_desc: "Wait 2 seconds".to_string(),
-                description: "Pauses execution for 2 seconds. Useful for waiting for terminal output or processes to complete.".to_string(),
+                name: "Sleep".to_string(),
+                short_desc: "Wait and refresh".to_string(),
+                description: "Pauses execution. Useful for waiting for terminal output or processes to complete.".to_string(),
                 params: vec![],
                 enabled: true,
                 category: ToolCategory::Console,
@@ -99,7 +99,7 @@ impl Module for TmuxModule {
             "console_create" => Some(self::tools::execute_create_pane(tool, state)),
             "console_edit" => Some(self::tools::execute_edit_config(tool, state)),
             "console_send_keys" => Some(self::tools::execute_send_keys(tool, state)),
-            "console_sleep" => Some(self::tools::execute_sleep(tool)),
+            "console_sleep" => Some(self::tools::execute_sleep(tool, state)),
             _ => None,
         }
     }


### PR DESCRIPTION
## Changes

- **console_send_keys**: waits 1s after sending keys, then synchronously captures pane content and updates the panel immediately
- **console_sleep**: after sleeping, synchronously refreshes ALL tmux panels  
- **Timer-based refresh**: tmux panels are now always interval-eligible (1s refresh), regardless of whether they're currently selected
- **TMUX_SEND_DELAY_MS**: increased from 300ms to 1000ms for reliable capture
- **Sleep tool**: renamed display to 'Sleep', updated description to be non-console-specific

## Problem

Tmux consoles were frequently stale — the AI would send commands but see outdated panel content. Three root causes:
1. send_keys didn't wait long enough or capture synchronously
2. sleep didn't refresh tmux panels
3. Timer refresh only ran for selected panels, so background consoles went stale