### PR TITLE
fix: block editing of built-in prompts

### DIFF
--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -29,6 +29,9 @@ echo "      Build complete."
 
 # 2. Install binary
 echo "[2/4] Installing to $INSTALL_PATH..."
+# Remove old binary first to avoid "Text file busy" when the running process holds it open.
+# The running process keeps its inode alive, but the directory entry is freed for the new copy.
+rm -f "$INSTALL_PATH"
 cp "$SCRIPT_DIR/target/release/tui" "$INSTALL_PATH"
 chmod +x "$INSTALL_PATH"
 echo "      Installed. ($(du -h "$INSTALL_PATH" | cut -f1))"

--- a/src/modules/prompt/tools/agent.rs
+++ b/src/modules/prompt/tools/agent.rs
@@ -87,6 +87,14 @@ pub fn edit(tool: &ToolUse, state: &mut State) -> ToolResult {
         }
     };
 
+    if agent.is_builtin {
+        return ToolResult {
+            tool_use_id: tool.id.clone(),
+            content: format!("Cannot edit built-in agent '{}'", id),
+            is_error: true,
+        };
+    }
+
     let mut changes = Vec::new();
 
     if let Some(name) = tool.input.get("name").and_then(|v| v.as_str()) {

--- a/src/modules/prompt/tools/command.rs
+++ b/src/modules/prompt/tools/command.rs
@@ -85,6 +85,14 @@ pub fn edit(tool: &ToolUse, state: &mut State) -> ToolResult {
         }
     };
 
+    if cmd.is_builtin {
+        return ToolResult {
+            tool_use_id: tool.id.clone(),
+            content: format!("Cannot edit built-in command '{}'", id),
+            is_error: true,
+        };
+    }
+
     let mut changes = Vec::new();
 
     if let Some(name) = tool.input.get("name").and_then(|v| v.as_str()) {

--- a/src/modules/prompt/tools/skill.rs
+++ b/src/modules/prompt/tools/skill.rs
@@ -85,6 +85,14 @@ pub fn edit(tool: &ToolUse, state: &mut State) -> ToolResult {
         }
     };
 
+    if skill.is_builtin {
+        return ToolResult {
+            tool_use_id: tool.id.clone(),
+            content: format!("Cannot edit built-in skill '{}'", id),
+            is_error: true,
+        };
+    }
+
     let mut changes = Vec::new();
 
     if let Some(name) = tool.input.get("name").and_then(|v| v.as_str()) {


### PR DESCRIPTION
Built-in agents, skills, and commands (from library.yaml) were already protected from deletion but could still be modified via the edit tools. This adds is_builtin checks to agent_edit, skill_edit, and command_edit.\n\nAlso includes a fix for deploy_local.sh to rm -f the old binary before copying, avoiding the 'Text file busy' error when deploying while the TUI is running.\n\nCloses #33