### PR TITLE
feat: log journaling — tree-structured log summarization with chunked persistence

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -28,10 +28,10 @@ pub const CHARS_PER_TOKEN: f32 = 3.3;
 pub const MEMORY_TLDR_MAX_TOKENS: usize = 80;
 
 /// Number of oldest active messages to carve off into a ConversationHistory panel.
-pub const DETACH_CHUNK_MESSAGES: usize = 25;
+pub const DETACH_CHUNK_MESSAGES: usize = 50;
 
 /// Minimum messages to keep in the live conversation after detachment.
-pub const DETACH_KEEP_MESSAGES: usize = 10;
+pub const DETACH_KEEP_MESSAGES: usize = 20;
 
 // =============================================================================
 // SCROLLING
@@ -124,6 +124,12 @@ pub const DEFAULT_WORKER_ID: &str = "main_worker";
 
 /// Presets subdirectory
 pub const PRESETS_DIR: &str = "presets";
+
+/// Logs subdirectory (chunked JSON files, global across workers)
+pub const LOGS_DIR: &str = "logs";
+
+/// Number of log entries per chunk file
+pub const LOGS_CHUNK_SIZE: usize = 1000;
 
 // =============================================================================
 // PANEL SIZE LIMITS

--- a/src/modules/logs/types.rs
+++ b/src/modules/logs/types.rs
@@ -6,6 +6,12 @@ pub struct LogEntry {
     pub id: String,
     pub timestamp_ms: u64,
     pub content: String,
+    /// If this log was summarized into a parent, the parent's ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    /// IDs of children logs that this entry summarizes (empty for leaf logs).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children_ids: Vec<String>,
 }
 
 impl LogEntry {
@@ -18,6 +24,8 @@ impl LogEntry {
             id,
             timestamp_ms,
             content,
+            parent_id: None,
+            children_ids: vec![],
         }
     }
 
@@ -27,6 +35,18 @@ impl LogEntry {
             id,
             timestamp_ms,
             content,
+            parent_id: None,
+            children_ids: vec![],
         }
+    }
+
+    /// Whether this log is a summary (has children).
+    pub fn is_summary(&self) -> bool {
+        !self.children_ids.is_empty()
+    }
+
+    /// Whether this log is top-level (no parent).
+    pub fn is_top_level(&self) -> bool {
+        self.parent_id.is_none()
     }
 }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -262,6 +262,7 @@ pub fn build_save_batch(state: &State) -> WriteBatch {
         dir.join(crate::constants::STATES_DIR),
         dir.join(crate::constants::PANELS_DIR),
         dir.join(crate::constants::MESSAGES_DIR),
+        dir.join(crate::constants::LOGS_DIR),
     ];
 
     // Build module data maps
@@ -298,6 +299,9 @@ pub fn build_save_batch(state: &State) -> WriteBatch {
             content: json.into_bytes(),
         });
     }
+
+    // Chunked log files (global, shared across workers)
+    writes.extend(crate::modules::logs::build_log_write_ops(&state.logs, state.next_log_id));
 
     // Build important_panel_uids
     let mut important_uids: HashMap<ContextType, String> = HashMap::new();

--- a/src/state/runtime.rs
+++ b/src/state/runtime.rs
@@ -85,6 +85,8 @@ pub struct State {
     pub logs: Vec<LogEntry>,
     /// Next log entry ID (L1, L2, ...)
     pub next_log_id: usize,
+    /// IDs of log summaries whose children are expanded (per-worker)
+    pub open_log_ids: Vec<String>,
     /// Spine notifications
     pub notifications: Vec<Notification>,
     /// Next notification ID (N1, N2, ...)
@@ -243,6 +245,7 @@ impl Default for State {
             next_scratchpad_id: 1,
             logs: vec![],
             next_log_id: 1,
+            open_log_ids: vec![],
             notifications: vec![],
             next_notification_id: 1,
             spine_config: SpineConfig::default(),


### PR DESCRIPTION
## Summary

- **LogEntry** gains parent_id and children_ids for tree structure
- **log_summarize** tool: min 10 entries, top-level only, creates parent summary
- **log_toggle** tool: expand/collapse summaries to show/hide children
- **Panel display**: tree rendering with triangles, child counts, indentation
- **Context output**: identical to panel display (collapsed hides children)
- **Persistence**: chunked JSON in .context-pilot/logs/ (batches of 1000)
- next_log_id stored globally in next_id.json
- Workers only store open_log_ids (per-worker expand state)
- Logs module is now is_global=true, saves via WriteBatch (no direct I/O)
- Bump DETACH_CHUNK_MESSAGES 25 to 50, DETACH_KEEP_MESSAGES 10 to 20