### PR TITLE
refactor(console): PTY-based architecture via script, escape sequences, context cap

### DIFF
--- a/crates/cp-base/src/state/runtime.rs
+++ b/crates/cp-base/src/state/runtime.rs
@@ -116,8 +116,6 @@ pub struct State {
     pub previous_panel_hash_list: Vec<String>,
     /// Sleep timer: if nonzero, tool pipeline should wait until this timestamp (ms) before proceeding
     pub tool_sleep_until_ms: u64,
-    /// Whether to refresh tmux panels after tool_sleep_until_ms expires (set by send_keys, not by sleep)
-    pub tool_sleep_needs_tmux_refresh: bool,
 
     // === Render Cache (runtime-only) ===
     /// Last viewport width (for pre-wrapping text)
@@ -198,7 +196,6 @@ impl Default for State {
             waiting_for_panels: false,
             previous_panel_hash_list: vec![],
             tool_sleep_until_ms: 0,
-            tool_sleep_needs_tmux_refresh: false,
             last_viewport_width: 0,
             message_cache: HashMap::new(),
             input_cache: None,

--- a/crates/cp-mod-preset/src/tools.rs
+++ b/crates/cp-mod-preset/src/tools.rs
@@ -241,14 +241,7 @@ pub(crate) fn execute_load(
         }
     }
 
-    // 5. Remove existing dynamic panels (kill tmux panes first)
-    for ctx in &state.context {
-        if ctx.context_type == ContextType::TMUX
-            && let Some(pane_id) = ctx.get_meta_str("tmux_pane_id")
-        {
-            let _ = std::process::Command::new("tmux").args(["kill-window", "-t", pane_id]).output();
-        }
-    }
+    // 5. Remove existing dynamic panels
     state.context.retain(|ctx| ctx.context_type.is_fixed());
 
     // 6. Recreate dynamic panels from preset config

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -55,8 +55,6 @@ pub struct App {
     deferred_tool_sleep_until_ms: u64,
     /// Whether we're in a deferred sleep state (waiting for timer before continuing tool pipeline)
     deferred_tool_sleeping: bool,
-    /// Whether to refresh tmux panels when deferred sleep expires (set by send_keys)
-    deferred_sleep_needs_tmux_refresh: bool,
     /// Background persistence writer — offloads file I/O to a dedicated thread
     writer: PersistenceWriter,
     /// Last poll time per panel ID — tracks when we last submitted a cache request
@@ -96,7 +94,6 @@ impl App {
             wait_started_ms: 0,
             deferred_tool_sleep_until_ms: 0,
             deferred_tool_sleeping: false,
-            deferred_sleep_needs_tmux_refresh: false,
             writer: PersistenceWriter::new(),
             last_poll_ms: std::collections::HashMap::new(),
             pending_question_tool_results: None,

--- a/src/app/run/lifecycle.rs
+++ b/src/app/run/lifecycle.rs
@@ -190,6 +190,13 @@ impl App {
                 self.typewriter.reset();
                 self.pending_done = None;
                 self.pending_tools.clear();
+
+                // Flush any pending blocking tool results as "interrupted" so their
+                // tool_use messages are properly paired with a tool_result.
+                // Without this, the orphaned tool_use causes API 400 errors on
+                // the next stream (tool_use without matching tool_result).
+                self.flush_pending_tool_results_as_interrupted();
+
                 // Pause auto-continuation when user explicitly cancels streaming.
                 // Without this, the spine would immediately relaunch a new stream
                 // (e.g., due to continue_until_todos_done), making the system

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,33 @@ fn main() -> io::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let resume_stream = args.iter().any(|a| a == "--resume-stream");
 
+    // Panic hook: restore terminal state and log the panic to disk.
+    // Without this, a panic leaves the terminal in raw mode + alternate screen,
+    // which corrupts the SSH session and the error is lost.
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = io::stdout().execute(DisableBracketedPaste);
+        let _ = io::stdout().execute(LeaveAlternateScreen);
+
+        // Write panic info to .context-pilot/errors/panic.log
+        let error_dir = std::path::Path::new(".context-pilot").join("errors");
+        let _ = std::fs::create_dir_all(&error_dir);
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        let msg = format!("[{}] {}\n\n{}\n\n---\n", ts, info, backtrace);
+        let log_path = error_dir.join("panic.log");
+        let _ = std::fs::OpenOptions::new().create(true).append(true).open(&log_path).and_then(|mut f| {
+            use std::io::Write;
+            f.write_all(msg.as_bytes())
+        });
+
+        default_hook(info);
+    }));
+
     enable_raw_mode()?;
     io::stdout().execute(EnterAlternateScreen)?;
     io::stdout().execute(EnableBracketedPaste)?;
@@ -41,6 +68,21 @@ fn main() -> io::Result<()> {
 
     // Initialize the ContextType registry from all modules (must happen before any is_fixed/icon/needs_cache calls)
     modules::init_registry();
+
+    // Remove orphaned context elements whose module no longer exists
+    // (e.g., tmux panels persisted before the tmux crate was removed).
+    {
+        let known_types: std::collections::HashSet<String> = modules::all_modules()
+            .iter()
+            .flat_map(|m| {
+                let mut types: Vec<String> = m.dynamic_panel_types().into_iter().map(|ct| ct.as_str().to_string()).collect();
+                types.extend(m.fixed_panel_types().into_iter().map(|ct| ct.as_str().to_string()));
+                types.extend(m.context_type_metadata().into_iter().map(|meta| meta.context_type.to_string()));
+                types
+            })
+            .collect();
+        state.context.retain(|c| known_types.contains(c.context_type.as_str()));
+    }
 
     // Ensure default context elements and seed exist
     ensure_default_contexts(&mut state);


### PR DESCRIPTION
## Changes

- Replace \`tail -f\` pipe wrapper with \`script -q -f -c\` for PTY emulation
- Stdin piped directly to script process (no more .in file)
- \`interpret_escapes()\` for send_keys: \`\\x03\` Ctrl+C, \`\\x04\` Ctrl+D, \`\\e\` ESC, \`\\xHH\` hex
- \`MAX_CONTEXT_CHARS=8000\` cap at cache level (token_count reflects real cost)
- Orphaned console panel cleanup on reload (Phase 3 in load_module_data)
- Remove \`input_path\` from SessionMeta and all file cleanup

## Fixes

- One-shot commands exit naturally (no more \`tail -f\` deadlock)
- Interactive programs get proper TTY (colors, line buffering)
- \`\$()\` subshell expansion works correctly
- Console output no longer floods LLM context (capped at ~2000 tokens)
- Orphaned panels cleaned up after reload

## Testing

All 20 tests pass: one-shot echo, interactive bash, docker postgres, send_keys with Ctrl+C, reload survival, panel close kills process, 2000-line buffer stress test.