### PR TITLE
feat(console): orphan process cleanup via env tag

### DIFF
--- a/crates/cp-mod-console/src/lib.rs
+++ b/crates/cp-mod-console/src/lib.rs
@@ -101,8 +101,16 @@ impl Module for ConsoleModule {
         };
 
         if sessions_map.is_empty() {
+            // No known sessions — kill any orphans from previous crashes
+            manager::kill_orphaned_processes(&std::collections::HashSet::new());
             return;
         }
+
+        // Collect known PIDs before orphan scan
+        let known_pids: std::collections::HashSet<u32> = sessions_map.values().map(|m| m.pid).collect();
+
+        // Kill any orphaned processes from previous crashes that aren't in our saved sessions
+        manager::kill_orphaned_processes(&known_pids);
 
         // Phase 1: Reconnect sessions (no &mut State needed)
         let mut reconnected: Vec<(String, SessionHandle)> = Vec::new();

--- a/crates/cp-mod-console/src/manager.rs
+++ b/crates/cp-mod-console/src/manager.rs
@@ -12,6 +12,71 @@ use crate::ring_buffer::RingBuffer;
 use crate::types::ProcessStatus;
 use crate::CONSOLE_DIR;
 
+/// Environment variable set on all spawned processes to tag them as TUI-launched.
+/// Value is a hash of the working directory so multiple TUI instances don't collide.
+pub const ENV_TAG: &str = "CONTEXT_PILOT_SESSION";
+
+/// Compute the session tag for the current working directory.
+pub fn session_tag() -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let mut hasher = DefaultHasher::new();
+    cwd.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Kill orphaned processes from previous TUI sessions that weren't cleaned up.
+/// Scans /proc for processes with our CONTEXT_PILOT_SESSION env var and kills
+/// any that aren't in the provided set of known PIDs.
+pub fn kill_orphaned_processes(known_pids: &std::collections::HashSet<u32>) {
+    let tag = session_tag();
+
+    // Scan /proc/*/environ for our tag
+    let proc_dir = match std::fs::read_dir("/proc") {
+        Ok(d) => d,
+        Err(_) => return, // Not on Linux or no /proc access
+    };
+
+    for entry in proc_dir.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        // Only look at numeric dirs (PIDs)
+        let pid: u32 = match name_str.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        // Skip our own PID and known live sessions
+        if pid == std::process::id() || known_pids.contains(&pid) {
+            continue;
+        }
+
+        // Read environ (null-separated key=value pairs)
+        let environ_path = format!("/proc/{}/environ", pid);
+        let environ = match std::fs::read(&environ_path) {
+            Ok(data) => data,
+            Err(_) => continue, // Permission denied or process gone
+        };
+
+        // Check if our tag is present
+        let needle = format!("{}={}", ENV_TAG, tag);
+        let needle_bytes = needle.as_bytes();
+
+        let found = environ
+            .split(|&b| b == 0)
+            .any(|entry| entry == needle_bytes);
+
+        if found {
+            // Orphan found — kill its process group
+            let _ = Command::new("kill").args(["-9", &format!("-{}", pid)]).output();
+            // Fallback: kill just the PID if group kill fails
+            let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+        }
+    }
+}
+
 /// A managed child process session.
 /// All fields are Send + Sync via Arc wrappers.
 pub struct SessionHandle {
@@ -64,6 +129,9 @@ impl SessionHandle {
         //   -c: run command instead of interactive shell
         let mut cmd = Command::new("script");
         cmd.args(["-q", "-f", "-c", &command, &log_path_str]);
+
+        // Tag the process so we can find orphans after crash/SIGKILL
+        cmd.env(ENV_TAG, session_tag());
 
         // Pipe stdin so we can send input via send_keys()
         // Stdout/stderr null — all output captured by script to the log file


### PR DESCRIPTION
## Problem

If the TUI crashes or is killed with SIGKILL, spawned console processes are orphaned forever — no cleanup happens because save_module_data never runs.

## Solution

Tag all spawned processes with a \`CONTEXT_PILOT_SESSION={cwd_hash}\` environment variable. On startup, scan \`/proc/*/environ\` for processes with our tag that aren't in saved sessions → kill them.

- Env vars are inherited by all children (including script's child processes)
- \`cwd_hash\` scopes by workspace — multiple TUI instances don't collide
- Works after crashes since the tag lives in the process, not in state files
- Linux-only (/proc), gracefully no-ops on other platforms