### PR TITLE
fix: add timeout guards + retry feedback to all LLM providers

### DIFF
--- a/src/app/run/streaming.rs
+++ b/src/app/run/streaming.rs
@@ -88,6 +88,16 @@ pub(super) fn process_stream_events(app: &mut App, rx: &Receiver<StreamEvent>) {
                 if will_retry {
                     app.state.api_retry_count = app.state.api_retry_count.saturating_add(1);
                     app.pending_retry_error = Some(e);
+                    // Show retry feedback — visible until handle_retry clears it next tick.
+                    let next_attempt = app.state.api_retry_count.saturating_add(1);
+                    let total_attempts = MAX_API_RETRIES.saturating_add(1);
+                    if let Some(msg) = app.state.messages.last_mut()
+                        && msg.role == "assistant"
+                    {
+                        msg.content = format!(
+                            "⏳ API error — retrying (attempt {next_attempt}/{total_attempts})…"
+                        );
+                    }
                 } else {
                     // Max retries reached, show error
                     app.state.api_retry_count = 0;
@@ -108,7 +118,9 @@ pub(super) fn handle_retry(app: &mut App, tx: &Sender<StreamEvent>) {
     if let Some(_error) = app.pending_retry_error.take() {
         // Still streaming, retry the request
         if app.state.flags.stream.phase.is_streaming() {
-            // Clear any partial assistant message content before retrying
+            // Clear partial content before prompt assembly — the retry feedback
+            // message (set in the error handler) must not leak into the LLM prompt
+            // or get prepended to the new streaming response.
             if let Some(msg) = app.state.messages.last_mut()
                 && msg.role == "assistant"
             {

--- a/src/llms/anthropic/mod.rs
+++ b/src/llms/anthropic/mod.rs
@@ -111,10 +111,7 @@ impl LlmClient for AnthropicClient {
     fn stream(&self, request: LlmRequest, tx: Sender<StreamEvent>) -> Result<(), LlmError> {
         let api_key = self.api_key.as_ref().ok_or_else(|| LlmError::Auth("ANTHROPIC_API_KEY not set".into()))?;
 
-        // timeout(None) prevents reqwest from killing long-running SSE streams.
-        // Without this, blocking Client may use system TCP timeouts, causing
-        // silent stream drops mid-response (same fix applied to Claude Code providers).
-        let client = Client::builder().timeout(None).build().map_err(|e| LlmError::Network(e.to_string()))?;
+        let client = crate::llms::build_sse_client()?;
 
         // Build API messages
         let include_tool_uses = request.tool_results.is_some();
@@ -173,13 +170,14 @@ impl LlmClient for AnthropicClient {
             let _r2 = std::fs::write(&path, serde_json::to_string_pretty(&api_request).unwrap_or_default());
         }
 
-        let response = client
-            .post(API_ENDPOINT)
-            .header("x-api-key", api_key.expose_secret())
-            .header("anthropic-version", API_VERSION)
-            .header("content-type", "application/json")
-            .json(&api_request)
-            .send()?;
+        let response = crate::llms::send_with_header_timeout(
+            client
+                .post(API_ENDPOINT)
+                .header("x-api-key", api_key.expose_secret())
+                .header("anthropic-version", API_VERSION)
+                .header("content-type", "application/json")
+                .json(&api_request),
+        )?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/llms/claude_code/mod.rs
+++ b/src/llms/claude_code/mod.rs
@@ -209,7 +209,7 @@ impl ClaudeCodeClient {
             .as_ref()
             .ok_or_else(|| LlmError::Auth("Claude Code OAuth token not found or expired. Run 'claude login'".into()))?;
 
-        let client = Client::builder().timeout(None).build().map_err(|e| LlmError::Network(e.to_string()))?;
+        let client = crate::llms::build_sse_client()?;
 
         // Handle cleaner mode or custom system prompt
         let system_text =
@@ -274,25 +274,26 @@ impl ClaudeCodeClient {
         // Always dump last request for debugging (overwritten each call)
         debug::dump_last_request(&request.worker_id, &api_request);
 
-        let response = client
-            .post(CLAUDE_CODE_ENDPOINT)
-            .header("accept", "text/event-stream")
-            .header("authorization", format!("Bearer {}", access_token.expose_secret()))
-            .header("anthropic-version", API_VERSION)
-            .header("anthropic-beta", OAUTH_BETA_HEADER)
-            .header("anthropic-dangerous-direct-browser-access", "true")
-            .header("content-type", "application/json")
-            .header("user-agent", "claude-cli/2.1.37 (external, cli)")
-            .header("x-app", "cli")
-            .header("x-stainless-arch", "x64")
-            .header("x-stainless-lang", "js")
-            .header("x-stainless-os", "Linux")
-            .header("x-stainless-package-version", "0.70.0")
-            .header("x-stainless-retry-count", "0")
-            .header("x-stainless-runtime", "node")
-            .header("x-stainless-runtime-version", "v24.3.0")
-            .json(&api_request)
-            .send()?;
+        let response = crate::llms::send_with_header_timeout(
+            client
+                .post(CLAUDE_CODE_ENDPOINT)
+                .header("accept", "text/event-stream")
+                .header("authorization", format!("Bearer {}", access_token.expose_secret()))
+                .header("anthropic-version", API_VERSION)
+                .header("anthropic-beta", OAUTH_BETA_HEADER)
+                .header("anthropic-dangerous-direct-browser-access", "true")
+                .header("content-type", "application/json")
+                .header("user-agent", "claude-cli/2.1.37 (external, cli)")
+                .header("x-app", "cli")
+                .header("x-stainless-arch", "x64")
+                .header("x-stainless-lang", "js")
+                .header("x-stainless-os", "Linux")
+                .header("x-stainless-package-version", "0.70.0")
+                .header("x-stainless-retry-count", "0")
+                .header("x-stainless-runtime", "node")
+                .header("x-stainless-runtime-version", "v24.3.0")
+                .json(&api_request),
+        )?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/llms/claude_code_api_key/mod.rs
+++ b/src/llms/claude_code_api_key/mod.rs
@@ -153,7 +153,7 @@ impl LlmClient for ClaudeCodeApiKeyClient {
         let api_key =
             self.api_key.as_ref().ok_or_else(|| LlmError::Auth("ANTHROPIC_API_KEY not found in environment".into()))?;
 
-        let client = Client::builder().timeout(None).build().map_err(|e| LlmError::Network(e.to_string()))?;
+        let client = crate::llms::build_sse_client()?;
 
         // Handle cleaner mode or custom system prompt
         let system_text =
@@ -215,10 +215,10 @@ impl LlmClient for ClaudeCodeApiKeyClient {
 
         dump_last_request(&request.worker_id, &api_request);
 
-        let response =
+        let response = crate::llms::send_with_header_timeout(
             apply_claude_code_headers(client.post(CLAUDE_CODE_ENDPOINT), api_key.expose_secret(), "text/event-stream")
-                .json(&api_request)
-                .send()?;
+                .json(&api_request),
+        )?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/llms/claude_code_v2/mod.rs
+++ b/src/llms/claude_code_v2/mod.rs
@@ -135,7 +135,7 @@ impl ClaudeCodeV2Client {
             .as_ref()
             .ok_or_else(|| LlmError::Auth("Claude Code OAuth token not found or expired. Run 'claude login'".into()))?;
 
-        let client = Client::builder().timeout(None).build().map_err(|e| LlmError::Network(e.to_string()))?;
+        let client = crate::llms::build_sse_client()?;
 
         // System prompt
         let system_text =
@@ -209,26 +209,27 @@ impl ClaudeCodeV2Client {
         helpers::dump_last_request(&request.worker_id, &api_request);
 
         // Build and send request with V2 headers
-        let response = client
-            .post(ENDPOINT)
-            .header("accept", "text/event-stream")
-            .header("authorization", format!("Bearer {}", access_token.expose_secret()))
-            .header("anthropic-version", API_VERSION)
-            .header("anthropic-beta", BETA_HEADER)
-            .header("anthropic-dangerous-direct-browser-access", "true")
-            .header("content-type", "application/json")
-            .header("user-agent", "claude-cli/2.1.170 (external, sdk-cli)")
-            .header("x-app", "cli")
-            .header("x-stainless-arch", "x64")
-            .header("x-stainless-lang", "js")
-            .header("x-stainless-os", "Linux")
-            .header("x-stainless-package-version", "0.94.0")
-            .header("x-stainless-retry-count", "0")
-            .header("x-stainless-runtime", "node")
-            .header("x-stainless-runtime-version", "v24.3.0")
-            .header("x-stainless-timeout", "600")
-            .json(&api_request)
-            .send()?;
+        let response = crate::llms::send_with_header_timeout(
+            client
+                .post(ENDPOINT)
+                .header("accept", "text/event-stream")
+                .header("authorization", format!("Bearer {}", access_token.expose_secret()))
+                .header("anthropic-version", API_VERSION)
+                .header("anthropic-beta", BETA_HEADER)
+                .header("anthropic-dangerous-direct-browser-access", "true")
+                .header("content-type", "application/json")
+                .header("user-agent", "claude-cli/2.1.170 (external, sdk-cli)")
+                .header("x-app", "cli")
+                .header("x-stainless-arch", "x64")
+                .header("x-stainless-lang", "js")
+                .header("x-stainless-os", "Linux")
+                .header("x-stainless-package-version", "0.94.0")
+                .header("x-stainless-retry-count", "0")
+                .header("x-stainless-runtime", "node")
+                .header("x-stainless-runtime-version", "v24.3.0")
+                .header("x-stainless-timeout", "600")
+                .json(&api_request),
+        )?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/llms/minimax/mod.rs
+++ b/src/llms/minimax/mod.rs
@@ -59,7 +59,7 @@ impl LlmClient for MiniMaxClient {
     fn stream(&self, request: LlmRequest, tx: Sender<StreamEvent>) -> Result<(), LlmError> {
         let api_key = self.api_key.as_ref().ok_or_else(|| LlmError::Auth("MINIMAX_API_KEY not set".into()))?;
 
-        let client = Client::builder().timeout(None).build().map_err(|e| LlmError::Network(e.to_string()))?;
+        let client = crate::llms::build_sse_client()?;
 
         // Use pre-assembled API messages from prompt_builder
         let include_tool_uses = request.tool_results.is_some();
@@ -115,13 +115,14 @@ impl LlmClient for MiniMaxClient {
             let _r2 = std::fs::write(&path, serde_json::to_string_pretty(&api_request).unwrap_or_default());
         }
 
-        let response = client
-            .post(MINIMAX_ENDPOINT)
-            .header("x-api-key", api_key.expose_secret())
-            .header("anthropic-version", MINIMAX_API_VERSION)
-            .header("content-type", "application/json")
-            .json(&api_request)
-            .send()?;
+        let response = crate::llms::send_with_header_timeout(
+            client
+                .post(MINIMAX_ENDPOINT)
+                .header("x-api-key", api_key.expose_secret())
+                .header("anthropic-version", MINIMAX_API_VERSION)
+                .header("content-type", "application/json")
+                .json(&api_request),
+        )?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/llms/mod.rs
+++ b/src/llms/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod minimax;
 pub(crate) mod oai_providers;
 
 use std::sync::mpsc::Sender;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -23,6 +24,13 @@ use crate::app::panels::ContextItem;
 use crate::infra::tools::ToolDefinition;
 use crate::infra::tools::ToolResult;
 use crate::state::Message;
+
+/// Maximum time to wait for TCP connection + TLS handshake (covers DNS + connect).
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum time to wait for response headers after sending the request body.
+/// Guards against overloaded servers that accept the connection but never reply.
+const HEADER_TIMEOUT: Duration = Duration::from_secs(60);
 
 // Re-export LLM types from cp-base so that `crate::llms::LlmProvider` etc. work
 pub(crate) use cp_base::config::llm_types::{ApiCheckResult, LlmProvider, ModelInfo, StreamEvent};
@@ -86,6 +94,49 @@ pub(crate) fn get_client(provider: LlmProvider) -> Box<dyn LlmClient> {
         LlmProvider::DeepSeek => Box::new(deepseek::DeepSeekClient::new()),
         LlmProvider::MiniMax => Box::new(minimax::MiniMaxClient::new()),
         LlmProvider::ClaudeCodeV2 => Box::new(claude_code_v2::ClaudeCodeV2Client::new()),
+    }
+}
+
+/// Build a `reqwest` blocking client with SSE-appropriate timeouts.
+///
+/// Sets a `connect_timeout` (30 s) so unreachable servers fail fast, but keeps
+/// the overall read timeout at `None` because legitimate SSE streams can last
+/// many minutes during long model responses.
+pub(crate) fn build_sse_client() -> Result<reqwest::blocking::Client, error::LlmError> {
+    reqwest::blocking::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(None)
+        .build()
+        .map_err(|e| error::LlmError::Network(e.to_string()))
+}
+
+/// Send a request with a header-timeout guard.
+///
+/// Spawns the blocking `.send()` on a helper thread and waits up to
+/// [`HEADER_TIMEOUT`] for a response. If the server accepts the TCP
+/// connection but never sends response headers (typical during overload),
+/// this returns `LlmError::Network` instead of blocking forever.
+///
+/// On timeout the helper thread is detached — it will eventually
+/// terminate when the underlying TCP connection closes or times out at the
+/// OS level.  This is acceptable: at most one orphan thread per failed
+/// stream attempt, and they park in a blocking `read` with no CPU cost.
+pub(crate) fn send_with_header_timeout(
+    builder: reqwest::blocking::RequestBuilder,
+) -> Result<reqwest::blocking::Response, error::LlmError> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let _handle = std::thread::spawn(move || {
+        let _r = tx.send(builder.send());
+    });
+
+    match rx.recv_timeout(HEADER_TIMEOUT) {
+        Ok(Ok(resp)) => Ok(resp),
+        Ok(Err(e)) => Err(error::LlmError::Network(e.to_string())),
+        Err(_timeout) => Err(error::LlmError::Network(format!(
+            "Request timed out after {}s waiting for response headers. \
+             The API server may be overloaded or unreachable.",
+            HEADER_TIMEOUT.as_secs()
+        ))),
     }
 }
 

--- a/src/llms/oai_providers/deepseek.rs
+++ b/src/llms/oai_providers/deepseek.rs
@@ -101,7 +101,7 @@ impl LlmClient for DeepSeekClient {
     fn stream(&self, request: LlmRequest, tx: Sender<StreamEvent>) -> Result<(), LlmError> {
         let api_key = self.api_key.as_ref().ok_or_else(|| LlmError::Auth("DEEPSEEK_API_KEY not set".into()))?;
 
-        let client = Client::new();
+        let client = crate::llms::build_sse_client()?;
         // V4 models use thinking mode by default — reasoning_content is always relevant
         let is_reasoner = true;
 
@@ -158,12 +158,13 @@ impl LlmClient for DeepSeekClient {
 
         super::openai_streaming::dump_request(&request.worker_id, "deepseek", &api_request);
 
-        let response = client
-            .post(DEEPSEEK_API_ENDPOINT)
-            .header("Authorization", format!("Bearer {}", api_key.expose_secret()))
-            .header("Content-Type", "application/json")
-            .json(&api_request)
-            .send()?;
+        let response = crate::llms::send_with_header_timeout(
+            client
+                .post(DEEPSEEK_API_ENDPOINT)
+                .header("Authorization", format!("Bearer {}", api_key.expose_secret()))
+                .header("Content-Type", "application/json")
+                .json(&api_request),
+        )?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/llms/oai_providers/grok.rs
+++ b/src/llms/oai_providers/grok.rs
@@ -62,7 +62,7 @@ impl LlmClient for GrokClient {
     fn stream(&self, request: LlmRequest, tx: Sender<StreamEvent>) -> Result<(), LlmError> {
         let api_key = self.api_key.as_ref().ok_or_else(|| LlmError::Auth("XAI_API_KEY not set".into()))?;
 
-        let client = Client::new();
+        let client = crate::llms::build_sse_client()?;
 
         // Collect pending tool result IDs
         let pending_tool_ids: Vec<String> = request
@@ -112,12 +112,13 @@ impl LlmClient for GrokClient {
 
         super::openai_streaming::dump_request(&request.worker_id, "grok", &api_request);
 
-        let response = client
-            .post(GROK_API_ENDPOINT)
-            .header("Authorization", format!("Bearer {}", api_key.expose_secret()))
-            .header("Content-Type", "application/json")
-            .json(&api_request)
-            .send()?;
+        let response = crate::llms::send_with_header_timeout(
+            client
+                .post(GROK_API_ENDPOINT)
+                .header("Authorization", format!("Bearer {}", api_key.expose_secret()))
+                .header("Content-Type", "application/json")
+                .json(&api_request),
+        )?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();

--- a/src/llms/oai_providers/groq.rs
+++ b/src/llms/oai_providers/groq.rs
@@ -65,7 +65,7 @@ impl LlmClient for GroqClient {
     fn stream(&self, request: LlmRequest, tx: Sender<StreamEvent>) -> Result<(), LlmError> {
         let api_key = self.api_key.as_ref().ok_or_else(|| LlmError::Auth("GROQ_API_KEY not set".into()))?;
 
-        let client = Client::new();
+        let client = crate::llms::build_sse_client()?;
 
         // Collect pending tool result IDs
         let pending_tool_ids: Vec<String> = request
@@ -121,12 +121,13 @@ impl LlmClient for GroqClient {
 
         super::openai_streaming::dump_request(&request.worker_id, "groq", &api_request);
 
-        let response = client
-            .post(GROQ_API_ENDPOINT)
-            .header("Authorization", format!("Bearer {}", api_key.expose_secret()))
-            .header("Content-Type", "application/json")
-            .json(&api_request)
-            .send()?;
+        let response = crate::llms::send_with_header_timeout(
+            client
+                .post(GROQ_API_ENDPOINT)
+                .header("Authorization", format!("Bearer {}", api_key.expose_secret()))
+                .header("Content-Type", "application/json")
+                .json(&api_request),
+        )?;
 
         if !response.status().is_success() {
             let status = response.status().as_u16();


### PR DESCRIPTION
## Problem

When an LLM API server is overloaded or unreachable, all providers either hang forever (\`timeout(None)\`) or use system TCP defaults (\`Client::new()\`). The user sees **zero feedback** — no error, no retry message — for up to 4 × 60s = 4 minutes of silent waiting.

## Root Cause

- **No connect timeout**: DNS/TCP failures block indefinitely
- **No header timeout**: \`.send()\` blocks waiting for response headers with no upper bound — the most dangerous case since the TCP connection is established but the server never sends response headers
- **Silent retries**: the retry loop (\`MAX_API_RETRIES=3\`, 4 total attempts) shows nothing to the user during retries

## Fix

### 1. Timeout guards (\`src/llms/mod.rs\`)

Two new shared helpers:

- **\`build_sse_client()\`** — reqwest blocking client with \`connect_timeout(30s)\` + \`timeout(None)\` (SSE streams legitimately run for minutes during long model responses)
- **\`send_with_header_timeout(builder)\`** — thread-based guard: spawns \`.send()\` on a helper thread, waits up to 60s for response headers. On timeout → \`LlmError::Network\` → feeds into the existing retry path. Orphan thread on timeout parks in a kernel read with no CPU cost.

### 2. Wired into all 8 providers

Replaced \`Client::builder().timeout(None).build()\` and \`Client::new()\` calls with \`build_sse_client()\`, and \`.send()?\` with \`send_with_header_timeout()\`:

| Provider | Old client | Old send |
|----------|-----------|----------|
| anthropic | \`timeout(None)\` | \`.send()?\` |
| claude_code | \`timeout(None)\` | \`.send()?\` |
| claude_code_api_key | \`timeout(None)\` | \`.send()?\` |
| claude_code_v2 | \`timeout(None)\` | \`.send()?\` |
| minimax | \`timeout(None)\` | \`.send()?\` |
| deepseek | \`Client::new()\` | \`.send()?\` |
| grok | \`Client::new()\` | \`.send()?\` |
| groq | \`Client::new()\` | \`.send()?\` |

\`check_api()\` methods are intentionally left unchanged — they are short-lived requests, not SSE streams.

### 3. Visible retry feedback (\`src/app/run/streaming.rs\`)

- **Error handler** (tick N): sets \`⏳ API error — retrying (attempt N/M)…\` in the assistant message — visible for ≥1 render frame before the next tick
- **handle_retry** (tick N+1): clears the message before prompt assembly, so it never leaks into the LLM prompt or gets prepended to the streaming response

## Files changed

\`\`\`
 src/app/run/streaming.rs            | 14 ++-
 src/llms/mod.rs                     | 51 ++++++++++++++++++++++++
 src/llms/anthropic/mod.rs           | 20 +++++-----
 src/llms/claude_code/mod.rs         | 41 ++++++++++----------
 src/llms/claude_code_api_key/mod.rs |  8 ++--
 src/llms/claude_code_v2/mod.rs      | 43 ++++++++++-----------
 src/llms/minimax/mod.rs             | 17 +++++----
 src/llms/oai_providers/deepseek.rs  | 15 ++++----
 src/llms/oai_providers/grok.rs      | 15 ++++----
 src/llms/oai_providers/groq.rs      | 15 ++++----
 10 files changed, 153 insertions(+), 86 deletions(-)
\`\`\`