### PR TITLE
ci(build): replace deprecated macos-13 runner with macos-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             artifact: cpilot-linux-aarch64
             cross: true
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             artifact: cpilot-macos-x86_64
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
## Problem

The \`cpilot-macos-x86_64\` build job in \`build.yml\` uses \`macos-13\` (Intel) runners, which were **retired by GitHub Actions in December 2025**. Jobs targeting this runner sit in \`queued\` state indefinitely — no runners are available.

This caused build run [28240789461](https://github.com/bigmoostache/context-pilot/actions/runs/28240789461) to appear stuck for 3+ hours.

## Fix

Replace \`os: macos-13\` with \`os: macos-latest\` (ARM64). The x86_64-apple-darwin target is still compiled correctly via \`rustup target add x86_64-apple-darwin\` — Rust cross-compiles x86_64 binaries on ARM Macs natively.

## Ref

- [GitHub changelog: macOS 13 runner closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [actions/runner-images#13046](https://github.com/actions/runner-images/issues/13046)