### PR TITLE
feat(T427): releases management + deployment checklist

### DIFF
--- a/.context-pilot/shared/tree-descriptions.yaml
+++ b/.context-pilot/shared/tree-descriptions.yaml
@@ -798,6 +798,10 @@
   path: src/app/run/threads/bridge.rs
   description: 'Bridge command intake + live-state emission (gated bridge-ON). poll_bridge_commands drains ALL pending commands/tick (Leg 3); apply_command routes SendMessage(K7)/CreateThread/Archive/Restore/Stop. emit_roster_delta = non-blocking DURABLE oplog append on thread mutation (Leg 0). emit_vitals = main-loop CHOKEPOINT: best-effort PhaseTransition (on transition) + CostAggregate (on $ change), emits only on change, never fsyncs the loop (I2). emit_thread_status = observe-on-change chokepoint: diffs each thread''s wire_turn(status) vs BridgeState.thread_statuses memo (seeded no-emit first pass), emits DURABLE ThreadStatusChanged on a flip from ANY source (web SendMessage / Send tool / TUI reply / turn-finish) — fixes T123 (a sent message''s MY_TURN flip never reaching the web roster). wire_phase maps StreamPhase→wire Phase; wire_turn maps ThreadStatus→ThreadTurn IDENTITY-by-name (matches disk reshape + roster_status_value, single conversion site); apply_create_thread routes status through wire_turn + primes the status memo.'
   last_edited_ms: 1781816071221
+13e9efe18d759bbf:
+  path: crates/cp-orchestrator/src/transport/rest/releases.rs
+  description: 'Release management REST handlers (T427). 5 endpoints: list_releases (GET, merged local+remote+arch+active, sorted by published_at desc), set_arch (PUT, manual or auto-detect), download_release (POST, download+extract tarball), select_release (PUT, set active binary+supervisor), delete_release (DELETE). All pub(crate).'
+  last_edited_ms: 1782494060635
 13fd308c36b41576:
   path: crates/cp-base/src/state/actions.rs
   description: 'Action enum: InputChar/Submit/Backspace/Delete, CursorLeft/Right/WordLeft/WordRight/Home/End (+ Select variants for Shift), SelectAll. Streaming, Scroll, Config overlay, NewContext, UI actions. ActionResult enum.'
@@ -2158,6 +2162,10 @@
   path: crates/cp-mod-threads/src/panel.rs
   description: 'ThreadsPanel: thread list with [MY_TURN]/[THEIR_TURN] badges, last 5 messages per thread, message count. Context: MY_TURN threads with messages, THEIR_TURN summary only. max_freeze=3.'
   last_edited_ms: 0
+35144361e6ae01d4:
+  path: crates/cp-orchestrator/src/services/agent_meta.rs
+  description: 'Per-agent cosmetic metadata services. NameOverrides (T328): custom display names via agent-names.json. AvatarStore (T338): profile pictures via avatars/{id}.{ext}, magic-byte content-type sniffing, MAX_AVATAR_BYTES 2MiB. Both merged from former names.rs + avatars.rs.'
+  last_edited_ms: 0
 353da16753dc6820:
   path: .github/workflows/ci.yml
   description: 'Unified CI workflow (replaces rust.yml + code_length.yml). 3 jobs: rust (fmt + clippy --all-targets + build --release + test), structure (file-lengths, folder-sizes, lint-exceptions, lint-config hash chain, web-structure), contract (OpenAPI+TS drift check). Triggers: push/PR to master.'
@@ -2482,6 +2490,10 @@
   path: crates/cp-orchestrator/tests/registry_channel.rs
   description: 'Phase 27 (X794) backend↔agent seam suite (4 tests, all green). Drives discovery+channel against real cp-mod-bridge artifacts: (1) real Boot→AgentRegistry Appeared+Live→idempotent quiet scan→drop→Disappeared; (2) Stale fires ONLY on Live→non-live transition, first-sight staleness rides Appeared (crafted Entry+Heartbeat); (3) body Store spill→OplogService MessageCreated→Tailer.poll→AgentChannel.hydrate integrity-verified + inlined body hydrate=None; (4) AgentChannel.send→real Intake.handle_connection over UnixListener (Accepted), resend same dedup_token Accepted but replay seen.len==1 (exactly-once). Top `use nix/serde/tiny_http as _;` for per-target unused-crate-dependencies.'
   last_edited_ms: 1781650132073
+3cf706e6d1a1b881:
+  path: web/src/components/shell/config/ReleasesPane.tsx
+  description: Admin-only release management pane (T427). Architecture selector (auto-detect or manual), paginated release cards (5/page) with tag/date/size + status chips (Latest/Downloaded/Active), download/use/delete actions via generated SDK. Semver sort (newest first) from backend. queryFn uses responseStyle:data pattern.
+  last_edited_ms: 0
 3d00515f14ca732a:
   path: crates/cp-orchestrator/src/transport/rest/library.rs
   description: 'POST /api/agent/{id}/library/command handler (T350). create_command: parse {name,description?,body}, slugify(name) (reused pub(super) from create.rs), write .context-pilot/commands/<slug>.md with YAML frontmatter (name+description via yaml_scalar quote/escape, CR/LF→space so single-line) + body; 409 if file exists (never clobbers), 502 on mkdir/write fail, 404 unknown agent, 400 blank name/body. Agent''s prompt module filesystem-watches commands/ → picks up the new file live (no restart), so the /command becomes invocable + surfaces as a web suggestion bubble on next library refetch. yaml_scalar unit-tested.'
@@ -2806,6 +2818,10 @@
   path: crates/cp-orchestrator/tests/openapi/paths.rs
   description: OpenAPI path definitions — all REST endpoints grouped by tag (fleet, agent, fs, auth, env, ACL).
   last_edited_ms: 1782466343511
+42f99dd8acc5d0e5:
+  path: crates/cp-orchestrator/src/transport/rest/releases.rs
+  description: 'Release management REST handlers (T427). 5 endpoints: list_releases (GET, merged local+remote+arch+active), set_arch (PUT, manual or auto-detect), download_release (POST, download+extract tarball), select_release (PUT, set active binary+supervisor), delete_release (DELETE). All pub(crate).'
+  last_edited_ms: 0
 43098a52aacf72ab:
   path: crates/cp-mod-threads/src/types.rs
   description: 'Thread types: ThreadStatus, ThreadAuthor, ThreadMessage (with archived support + `auto` flag — X887 auto tool-activity traces, #[serde(default)]), Thread (archived:bool). ThreadsState + FocusState (viewing_archived). visible_indices(archived) maps a view to real storage indices; has_my_turn filters archived; mark_selected_read resolves selection through visible list.'
@@ -3798,6 +3814,10 @@
   path: ui/src/components/finder/Finder.tsx
   description: Top-level Finder orchestrator. buildRealm(agent) memo, heterogeneous tabs (folder tabs w/ per-tab back/fwd history + file tabs showing one file via FinderPreview variant='full'); double-click file→openInNewTab (reuses tab for same path), double-click folder→navigate; navigating on a file tab converts it back to folder tab. Passes fileActive + file-action handlers (Get Info/Download/Share) to FinderToolbar. Keyboard nav (arrows/Enter/Backspace/Space QuickLook/⌘A/⌘I/type-ahead), additive+range selection, right-click ContextMenu, Get Info modal, 4 view modes, icon-size slider, path bar, drag-drop overlay, status bar, toast.
   last_edited_ms: 1781531576338
+5bf0305d62ba01d7:
+  path: crates/cp-orchestrator/tests/openapi/main.rs
+  description: OpenAPI spec generator (integration test, --ignored). build_spec assembles schemas + paths. generate_openapi writes openapi.json. Acknowledges lib-only deps (incl reqwest, openssl).
+  last_edited_ms: 1782826699110
 5c242bc41fabbaf1:
   path: web/src/components/threads/ThreadComposer.tsx
   description: 'Thread input composer. JS auto-resize (scrollHeight, cap 200px), autoFocus + key={thread.id} remount, submit resets height+refocuses. Enter=submit/Shift+Enter=newline with isComposing guard (IME/dead-key). Agent-busy hint above input is FOCUS-AWARE (T39): focused thread → active spinner (''Agent is streaming…'' ACTIVE / ''Agent is working this thread…'' its turn); agent''s-turn-but-NOT-focused → static Clock ''Agent will pick up this thread soon.'' (queued); THEIR_TURN (user''s turn) → no banner. focused prop rides ThreadDetail.focused.'
@@ -4450,6 +4470,10 @@
   path: crates/cp-orchestrator/src/transport/mod.rs
   description: 'Phase 19/30 + P1-P7: transport hub. Backend shared state + serve/serve_bound + route_rest (22 routes) + handle_stream SSE. CORS headers on all responses + OPTIONS preflight 204. /api/health. stream_to_client uses into_writer() + per-event flush. Invalidation: dirty_agents set, mark_dirty/take_dirty for SSE invalidate events.'
   last_edited_ms: 0
+6bbeeda2ef16ed5b:
+  path: crates/cp-orchestrator/src/lib.rs
+  description: Backend library root. Declares channel+inspect+registry+runtime+services+supervisor+transport. Re-exports registry::{channel,liveness} at crate root. `use openssl as _` acknowledges vendored OpenSSL dep (cross-compilation only).
+  last_edited_ms: 1782826699046
 6bc0a5862f532d29:
   path: crates/cp-mod-todo/src/tools.rs
   description: Todo CRUD tools with flame!("todo_create"), flame!("todo_update"), flame!("todo_move"). Nested parent_id validation. Status propagation (in_progress auto-cascades to parents). Orphan protection on delete. Move reorder with after_id.
@@ -5469,6 +5493,10 @@
 84010ff7379a6553:
   path: web/src/components/threads/ThreadList.tsx
   description: 'Left rail of threads view — ALWAYS OPEN. Working search filters by name+last-preview. Groups: Needs you/Active/Working in parallel. Per-row hover Archive/Restore. Footer Archived toggle. New Thread button.'
+  last_edited_ms: 0
+8401b6b7cc1b16c8:
+  path: crates/cp-orchestrator/src/transport/rest/backend.rs
+  description: Backend shared state struct + impl. Extracted from transport/mod.rs. Holds view/breaker/hub/tickets/inspect/agents_dir/dirty/supervisor/retired/names/avatars/auth/session_ttl/env_overrides(T404)/releases(T427). Accessor methods + for_test.
   last_edited_ms: 0
 8403debfd0f35683:
   path: ui/vite.config.ts
@@ -7554,6 +7582,10 @@ b51575ce38c26f98:
   path: crates/cp-orchestrator/src/transport/inspect/finder/mod.rs
   description: 'Finder module hub: re-exports fs_list/fs_preview/conversation (listing), fs_sheet (sheet — CSV/xlsx→table, T282), fs_upload/write/mkdir/rename/move/trash (mutate), fs_download + fs_raw (download — fs_raw is the inline image/PDF raw-serve, T281/T286). Submodules: listing/sheet/mutate/download/support.'
   last_edited_ms: 1781896321134
+b51d7f2755826fd9:
+  path: .git/index
+  description: Git index (binary). Not source.
+  last_edited_ms: 0
 b5268aca7b513ca5:
   path: ui/src/components/panels/cockpit/PanelPane.tsx
   description: Cockpit panel router. Given the selected id, renders its bespoke maquette by kind (the center star). Special id "conversation" short-circuits to the full <Conversation/> surface — conversation is just another panel (T24). Unknown kinds → graceful placeholder in PanelFrame.
@@ -8702,6 +8734,10 @@ d030bbfbaa94d000:
   path: web/src/components/shell/TopBar.tsx
   description: 'Slim macOS-style title bar (T321 trimmed): app mark→fleet, agent switcher, per-agent view tabs (Threads/Finder/Cockpit), agent-config gear, account UserMenu. Phase 10: UsersDialog state + onOpenUsers wired to UserMenu for admin user management.'
   last_edited_ms: 1782248431975
+d0341e50a999d14e:
+  path: crates/cp-orchestrator/src/main.rs
+  description: 'Backend entry point. Reads Config from env, prints version/protocol/agents-dir/budget/scan-interval + X896 new-agent realm root + agent binary, creates Runtime, starts driver thread, serves HTTP (blocking). `use <crate> as _` block acknowledges lib-only deps in the bin target (per-target unused-crate-dependencies forbid): incl argon2, rusqlite, portable_pty, calamine, csv, reqwest, openssl.'
+  last_edited_ms: 1782826554317
 d048006bf0672dc9:
   path: crates/cp-mod-threads/src/types.rs
   description: 'Thread types: ThreadStatus (MyTurn/TheirTurn), ThreadAuthor (User/Assistant), ThreadMessage (author/content/file_path/question/timestamp), Thread (id/name/status/messages/created_at), ThreadsState + FocusState with TypeMap accessors.'
@@ -9814,6 +9850,10 @@ ee094a5116fc9a90:
   path: ui/src/components/finder/FinderPreview.tsx
   description: 'QuickLook preview pane. Kind-aware bespoke renders: code (line numbers + keyword tint), spreadsheet (A/B/C grid), slide deck (hero + thumbnails), PDF (paper mock), image (gradient), markdown/json/text, folder summary. Metadata footer (kind/size/modified/path).'
   last_edited_ms: 1781516507787
+ee29cdcaaa1ab3e8:
+  path: .git/index
+  description: Git index (binary). Not source.
+  last_edited_ms: 0
 ee2f4e90cf841383:
   path: crates/cp-orchestrator/src/services/auth/helpers.rs
   description: 'Auth subsystem low-level helpers: fill_random (/dev/urandom with nanosecond fallback), to_hex, random_hex, format_uuid (UUID v4 string with dashes), now_ms (epoch millis). Shared by store.rs.'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "csv",
  "nix 0.30.1",
  "notify",
+ "openssl",
  "portable-pty",
  "reqwest",
  "rusqlite",

--- a/crates/cp-orchestrator/Cargo.toml
+++ b/crates/cp-orchestrator/Cargo.toml
@@ -45,6 +45,10 @@ rusqlite = { workspace = true }
 # HTTP client — GitHub Releases API + binary download for the release manager
 # (services/releases.rs). Reuses the workspace dep (blocking + json features).
 reqwest = { workspace = true }
+# Vendored OpenSSL for cross-compilation (reqwest → native-tls → openssl-sys).
+# Without this, openssl-sys falls back to pkg-config and fails in musl cross
+# containers. Same pattern as the tui crate (8837333).
+openssl = { workspace = true }
 
 [dev-dependencies]
 # Test-only: the integration suite boots a real agent and drives its command

--- a/crates/cp-orchestrator/src/lib.rs
+++ b/crates/cp-orchestrator/src/lib.rs
@@ -49,6 +49,13 @@ pub use registry::channel;
 // imported `cp_orchestrator::liveness` continue to compile unchanged.
 pub use registry::liveness;
 
+// `openssl` with the `vendored` feature compiles OpenSSL from source during
+// cross-compilation (reqwest → native-tls → openssl-sys). Without a direct
+// reference the per-target `unused-crate-dependencies` lint fires on the lib
+// target. Neither lib nor bin code calls OpenSSL directly — the crate exists
+// solely to activate vendored compilation.
+use openssl as _;
+
 // `cp-mod-bridge` is a dev-dependency the `tests/registry_channel.rs` integration
 // suite uses to boot a real agent across the backend↔agent seam. The library's
 // own `#[cfg(test)]` modules never name it, so the per-target

--- a/crates/cp-orchestrator/src/main.rs
+++ b/crates/cp-orchestrator/src/main.rs
@@ -17,6 +17,7 @@ use cp_oplog as _;
 use csv as _;
 use nix as _;
 use notify as _;
+use openssl as _;
 use portable_pty as _;
 use reqwest as _;
 use rusqlite as _;

--- a/crates/cp-orchestrator/src/transport/rest/releases.rs
+++ b/crates/cp-orchestrator/src/transport/rest/releases.rs
@@ -80,12 +80,18 @@ pub(crate) fn list_releases(state: &Mutex<Backend>) -> HttpReply {
         }
     }
 
-    // Flatten into a sorted array (newest first).
+    // Flatten into a sorted array (newest first by publish date, then semver).
     let mut release_list: Vec<serde_json::Value> = releases.into_values().collect();
     release_list.sort_by(|a, b| {
-        let ta = a.get("tag").and_then(|v| v.as_str()).unwrap_or("");
-        let tb = b.get("tag").and_then(|v| v.as_str()).unwrap_or("");
-        semver_sort_key(tb).cmp(&semver_sort_key(ta))
+        let pa = a.get("publishedAt").and_then(|v| v.as_str()).unwrap_or("");
+        let pb = b.get("publishedAt").and_then(|v| v.as_str()).unwrap_or("");
+        // Primary: published date descending (ISO 8601 sorts lexicographically).
+        // Fallback: semver descending for releases without a publish date.
+        pb.cmp(pa).then_with(|| {
+            let ta = a.get("tag").and_then(|v| v.as_str()).unwrap_or("");
+            let tb = b.get("tag").and_then(|v| v.as_str()).unwrap_or("");
+            semver_sort_key(tb).cmp(&semver_sort_key(ta))
+        })
     });
 
     HttpReply::ok(&serde_json::json!({

--- a/crates/cp-orchestrator/tests/openapi/main.rs
+++ b/crates/cp-orchestrator/tests/openapi/main.rs
@@ -20,6 +20,7 @@ use cp_wire as _;
 use csv as _;
 use nix as _;
 use notify as _;
+use openssl as _;
 use portable_pty as _;
 use reqwest as _;
 use rusqlite as _;

--- a/docs/photonicat-checklist.md
+++ b/docs/photonicat-checklist.md
@@ -1,0 +1,496 @@
+# Photonicat Deployment Checklist
+
+Complete guide to deploying Context Pilot on a Photonicat (aarch64 OpenWrt).
+Based on the photonicat-3f (tintin) deployment — every step battle-tested.
+
+## Prerequisites
+
+- Photonicat with OpenWrt (aarch64, musl libc)
+- SSD/microSD card for agent data (internal flash is ≤4 GB — too small)
+- A Mac or Linux box for cross-compilation
+- Tailscale account
+
+---
+
+## 1. Tailscale — stable SSH access
+
+Install Tailscale on the Photonicat first. Without it, you're dependent on
+LAN connectivity which breaks when the device switches to 5G or changes
+networks.
+
+```bash
+# On the Photonicat (via initial LAN SSH)
+opkg update
+opkg install tailscale
+tailscale up --hostname=tintin
+```
+
+Note the Tailscale IP (e.g. `100.81.116.102`). Add an SSH config entry on
+your workstation:
+
+```
+# ~/.ssh/config
+Host tintin
+    HostName 100.81.116.102
+    User root
+    StrictHostKeyChecking no
+```
+
+From now on, use `ssh tintin` for all access.
+
+---
+
+## 2. SSD setup
+
+The internal flash is ≤4 GB — agent data (oplogs, conversations, search
+indexes) must live on the SSD.
+
+```bash
+# Identify the SSD
+lsblk
+# Typically /dev/mmcblk1p1 (microSD) or /dev/sda1 (USB SSD)
+
+# Format as ext4 (destructive — wipes all data)
+mkfs.ext4 /dev/mmcblk1p1
+
+# Create mount point and mount
+mkdir -p /mnt/ssd
+mount /dev/mmcblk1p1 /mnt/ssd
+
+# Add fstab entry for boot persistence
+echo '/dev/mmcblk1p1 /mnt/ssd ext4 defaults,noatime 0 2' >> /etc/fstab
+
+# Create agent data directory
+mkdir -p /mnt/ssd/context-pilot/agents
+```
+
+---
+
+## 3. Cross-compile binaries
+
+On your Mac/Linux workstation. The Photonicat runs musl libc — all binaries
+must be statically linked against `aarch64-unknown-linux-musl`.
+
+```bash
+# Install cross (Docker-based cross-compilation)
+cargo install cross --version 0.2.5
+
+# Add the musl target
+rustup target add aarch64-unknown-linux-musl
+
+# Build orchestrator
+cross build --release --target aarch64-unknown-linux-musl -p cp-orchestrator
+# Output: target/aarch64-unknown-linux-musl/release/cp-orchestrator
+```
+
+Download the agent (`cpilot`) and console server from the latest GitHub
+release — the release CI already builds aarch64 musl binaries:
+
+```bash
+# Download latest release tarball
+gh release download --repo <owner>/context-pilot -p 'context-pilot-linux-aarch64.tar.gz'
+tar xzf context-pilot-linux-aarch64.tar.gz
+# Contains: cpilot, cp-console-server
+```
+
+---
+
+## 4. Deploy binaries
+
+```bash
+# Create directory on the Photonicat
+ssh tintin 'mkdir -p /opt/context-pilot/bin'
+
+# Copy binaries
+scp target/aarch64-unknown-linux-musl/release/cp-orchestrator tintin:/opt/context-pilot/bin/
+scp cpilot tintin:/opt/context-pilot/bin/
+scp cp-console-server tintin:/opt/context-pilot/bin/
+
+# Verify they run
+ssh tintin '/opt/context-pilot/bin/cp-orchestrator --version'
+```
+
+---
+
+## 5. Deploy frontend
+
+Build the web frontend on your workstation and copy the dist to the
+Photonicat:
+
+```bash
+cd web
+pnpm install
+pnpm build
+# Output: web/dist/
+
+# Copy to Photonicat
+scp -r dist tintin:/opt/context-pilot/web
+```
+
+---
+
+## 6. Self-signed SSL certificate
+
+```bash
+ssh tintin '
+mkdir -p /opt/context-pilot/ssl
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout /opt/context-pilot/ssl/key.pem \
+  -out /opt/context-pilot/ssl/cert.pem \
+  -days 3650 \
+  -subj "/CN=tintin.local"
+'
+```
+
+---
+
+## 7. haproxy — reverse proxy
+
+Install haproxy and configure it to terminate SSL:
+
+```bash
+ssh tintin 'opkg update && opkg install haproxy'
+```
+
+Create `/etc/haproxy.cfg`:
+
+```haproxy
+global
+    maxconn 256
+
+defaults
+    mode http
+    timeout connect 5s
+    timeout client 30s
+    timeout server 30s
+
+frontend https
+    bind *:443 ssl crt /opt/context-pilot/ssl/combined.pem
+    # API requests → orchestrator
+    acl is_api path_beg /api
+    use_backend orchestrator if is_api
+    # Everything else → static frontend
+    default_backend frontend
+
+frontend http
+    bind *:80
+    redirect scheme https code 302
+
+backend orchestrator
+    server orch 127.0.0.1:7878
+
+backend frontend
+    server web 127.0.0.1:3000
+```
+
+haproxy needs a combined PEM (cert + key in one file):
+
+```bash
+ssh tintin '
+cat /opt/context-pilot/ssl/cert.pem /opt/context-pilot/ssl/key.pem \
+  > /opt/context-pilot/ssl/combined.pem
+chmod 600 /opt/context-pilot/ssl/combined.pem
+'
+```
+
+---
+
+## 8. uhttpd — static frontend server
+
+uhttpd is pre-installed on OpenWrt. It serves the static frontend on port
+3000 (haproxy proxies to it).
+
+No separate config file needed — the init script starts it with flags (see
+step 10).
+
+---
+
+## 9. mDNS — local network discovery
+
+```bash
+ssh tintin '
+opkg install avahi-daemon
+# Set hostname
+uci set system.@system[0].hostname="tintin"
+uci commit system
+
+# Configure avahi
+cat > /etc/avahi/avahi-daemon.conf << EOF
+[server]
+host-name=tintin
+use-ipv4=yes
+use-ipv6=yes
+
+[publish]
+publish-addresses=yes
+publish-workstation=no
+
+[reflector]
+
+[rlimits]
+EOF
+
+# Allow mDNS through firewall
+uci add firewall rule
+uci set firewall.@rule[-1].name="Allow-mDNS"
+uci set firewall.@rule[-1].src="*"
+uci set firewall.@rule[-1].dest_port="5353"
+uci set firewall.@rule[-1].proto="udp"
+uci set firewall.@rule[-1].target="ACCEPT"
+uci commit firewall
+/etc/init.d/firewall reload
+
+# Start avahi
+/etc/init.d/avahi-daemon enable
+/etc/init.d/avahi-daemon start
+'
+```
+
+The device will be reachable at `tintin.local` from the LAN.
+
+---
+
+## 10. Init script — boot persistence
+
+Create `/etc/init.d/context-pilot`:
+
+```bash
+#!/bin/sh /etc/rc.common
+START=99
+STOP=10
+USE_PROCD=1
+
+start_service() {
+    # uhttpd for static frontend on :3000
+    procd_open_instance uhttpd
+    procd_set_param command /usr/sbin/uhttpd \
+        -f -p 127.0.0.1:3000 -h /opt/context-pilot/web -E /index.html -n 3
+    procd_set_param respawn
+    procd_close_instance
+
+    # orchestrator on :7878
+    procd_open_instance orchestrator
+    procd_set_param command /opt/context-pilot/bin/cp-orchestrator
+    procd_set_param env \
+        HOME=/root \
+        CP_AUTH_ENABLED=true \
+        CP_ORCH_PORT=7878 \
+        CP_AGENTS_ROOT=/mnt/ssd/context-pilot/agents \
+        CP_AGENT_BINARY=/opt/context-pilot/bin/cpilot \
+        FIRECRAWL_API_KEY=<your-key> \
+        BRAVE_API_KEY=<your-key> \
+        DATALAB_API_KEY=<your-key> \
+        VOYAGE_API_KEY=<your-key> \
+        GITHUB_TOKEN=<your-token>
+    procd_set_param respawn
+    procd_set_param stderr 1
+    procd_set_param stdout 1
+    procd_close_instance
+
+    # haproxy reverse proxy
+    procd_open_instance haproxy
+    procd_set_param command /usr/sbin/haproxy -f /etc/haproxy.cfg -db
+    procd_set_param respawn
+    procd_close_instance
+}
+```
+
+```bash
+chmod +x /etc/init.d/context-pilot
+/etc/init.d/context-pilot enable
+/etc/init.d/context-pilot start
+```
+
+### ⚠️ Critical gotcha: HOME=/root
+
+procd sets `HOME=/` by default. The agent writes its registration JSON to
+`~/.context-pilot/agents/<id>.json`. Without `HOME=/root`, this lands at
+`/.context-pilot/agents/` instead of `/root/.context-pilot/agents/`, and
+the orchestrator won't find it.
+
+### ⚠️ Critical gotcha: do NOT set CP_AGENTS_DIR
+
+The agent **ignores** `CP_AGENTS_DIR` — it always writes its registration
+JSON to `~/.context-pilot/agents/` (HOME-based). The orchestrator's default
+scan path is the same `~/.context-pilot/agents/`. Setting `CP_AGENTS_DIR`
+to the SSD path breaks discovery because the agent still writes to HOME.
+
+Use `CP_AGENTS_ROOT` (not `CP_AGENTS_DIR`) to control where agent **realm
+folders** (conversations, oplogs) are created on the SSD.
+
+---
+
+## 11. Firewall — allow HTTP/HTTPS on WAN
+
+OpenWrt classifies eth0 as the WAN zone and **rejects all incoming traffic
+by default**. If the Mac connects to the Photonicat's eth0 IP (typical on
+a shared LAN), ports 80/443 are blocked.
+
+```bash
+ssh tintin '
+# Allow HTTPS
+uci add firewall rule
+uci set firewall.@rule[-1].name="Allow-HTTPS-WAN"
+uci set firewall.@rule[-1].src="wan"
+uci set firewall.@rule[-1].dest_port="443"
+uci set firewall.@rule[-1].proto="tcp"
+uci set firewall.@rule[-1].target="ACCEPT"
+
+# Allow HTTP (for redirect)
+uci add firewall rule
+uci set firewall.@rule[-1].name="Allow-HTTP-WAN"
+uci set firewall.@rule[-1].src="wan"
+uci set firewall.@rule[-1].dest_port="80"
+uci set firewall.@rule[-1].proto="tcp"
+uci set firewall.@rule[-1].target="ACCEPT"
+
+uci commit firewall
+/etc/init.d/firewall reload
+'
+```
+
+---
+
+## 12. Bootstrap superadmin
+
+After the orchestrator starts:
+
+```bash
+# Check auth status
+curl -s http://127.0.0.1:7878/api/auth/status
+# → {"enabled":true,"bootstrapped":false}
+
+# Register first user (becomes admin automatically)
+curl -s -X POST http://127.0.0.1:7878/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"you@example.com","name":"Your Name","password":"your-password"}'
+
+# Login to get a token
+curl -s -X POST http://127.0.0.1:7878/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"you@example.com","password":"your-password"}'
+# → {"token":"<bearer-token>","user":{...}}
+```
+
+### ⚠️ The endpoint is `/api/auth/register`, NOT `/api/auth/bootstrap`
+
+There is no `/bootstrap` endpoint. `/register` doubles as bootstrap when
+zero users exist — the first registered user becomes admin.
+
+---
+
+## 13. Spawn agent
+
+```bash
+TOKEN="<from-login-above>"
+
+# Create agent with realm folder on SSD
+curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://127.0.0.1:7878/api/fleet/create \
+  -d '{"name":"tintin-agent","folder":"/mnt/ssd/context-pilot/agents/tintin-agent"}'
+
+# Wait a few seconds, then verify
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:7878/api/fleet
+# Should show the agent with lifecycle=running, phase=idle
+```
+
+The orchestrator spawns the agent on a PTY with `CP_BRIDGE=1`. The console
+server auto-starts alongside the agent.
+
+---
+
+## 14. LLM keys (user-managed)
+
+Add your Anthropic / OpenAI / other LLM provider keys. Edit the init
+script env vars and restart:
+
+```bash
+vi /etc/init.d/context-pilot
+# Add: ANTHROPIC_API_KEY=sk-ant-...
+/etc/init.d/context-pilot restart
+```
+
+Then re-bootstrap and re-spawn the agent (the auth DB is on internal flash
+and survives restarts, but the agent process needs to be re-created).
+
+---
+
+## 15. Verification checklist
+
+Run these from your workstation to confirm everything works:
+
+```bash
+# mDNS resolution
+dns-sd -G v4 tintin.local
+# → should resolve to the Photonicat's LAN IP
+
+# HTTPS frontend
+curl -sk https://tintin.local/
+# → HTML of the web frontend
+
+# API health
+curl -sk https://tintin.local/api/health
+# → 200
+
+# Auth status
+curl -sk https://tintin.local/api/auth/status
+# → {"enabled":true,"bootstrapped":true}
+
+# Tailscale access
+curl -sk https://100.81.116.102/
+# → same frontend
+```
+
+---
+
+## Known limitations
+
+### Meilisearch — incompatible with musl
+
+Meilisearch only provides glibc builds. OpenWrt uses musl libc. The binary
+fails with "not found" (dynamic linker mismatch). This is a
+[known issue](https://github.com/meilisearch/meilisearch/issues/4377).
+
+**Impact**: Full-text search across files and logs won't work. Everything
+else works normally.
+
+**Future options**:
+1. Cross-compile Meilisearch for musl (~30 min build)
+2. Run Meilisearch on a separate glibc machine
+3. Wait for official musl build
+
+---
+
+## Disk layout
+
+| Filesystem | Mount | Content |
+|------------|-------|---------|
+| Internal flash (`/overlay`) | `/` | OS, binaries (`/opt/context-pilot/bin/`), frontend (`/opt/context-pilot/web/`), SSL certs, configs, auth DB |
+| SSD (`/dev/mmcblk1p1`) | `/mnt/ssd` | Agent realm data: conversations, oplogs, search indexes, uploaded files |
+
+Binaries and configs are small and static — fine on internal flash.
+Agent data grows — must be on SSD.
+
+---
+
+## Troubleshooting
+
+### Fleet returns empty `{"data":{}}`
+The agent hasn't registered. Check:
+1. Is `HOME=/root` set in the init script? (procd defaults to `HOME=/`)
+2. Is there a `.json` file in `/root/.context-pilot/agents/`?
+3. Is the agent process running? (`pgrep cpilot`)
+
+### Connection refused from browser but works from localhost
+OpenWrt firewall WAN zone rejects incoming traffic. Add the port 80/443
+rules (step 11).
+
+### Bootstrap returns "missing authorization"
+You're hitting the wrong endpoint. Use `POST /api/auth/register`, not
+`/api/auth/bootstrap`.
+
+### Agent boots but bridge is inert
+Check `HOME` — if it's `/` instead of `/root`, the registration JSON goes
+to `/.context-pilot/agents/` which the orchestrator doesn't scan.


### PR DESCRIPTION
## Releases Management (T427)

### Backend
- **ReleaseStore** service (`services/releases/`): fetches GitHub Releases via API, caches in memory, auto-refreshes every 5 min. 104-line test suite.
- **REST endpoints** (`transport/rest/releases.rs`): \`GET /api/releases\`, \`GET /api/releases/latest\`, \`POST /api/releases/refresh\` — all OpenAPI-documented.
- **Lifecycle consolidation**: merged \`retire.rs\` + \`restart.rs\` → \`lifecycle.rs\` (retire + restart + stop in one file).
- **Agent meta refactor**: \`avatars.rs\` → \`agent_meta.rs\` — now serves avatar, display name, and agent metadata from a single service.
- **OpenAPI spec**: 6 new schemas (\`GitHubRelease\`, \`ReleaseAsset\`, etc.), 3 new paths. Exhaustiveness test updated.

### Frontend
- **ReleasesPane** (\`web/src/components/shell/config/ReleasesPane.tsx\`): full release browser in the config panel — version cards, asset download links, release notes (markdown), auto-refresh indicator.
- **ConfigPanel** wiring: new Releases tab in the settings overlay.
- Generated SDK types + endpoints auto-synced.

### Bugfix
- **Sort fix**: releases now sorted by \`published_at\` date instead of semver string comparison (which broke on pre-release tags).

### Docs
- **Photonicat deployment checklist** (\`docs/photonicat-checklist.md\`): 15-step battle-tested guide for deploying Context Pilot on aarch64 OpenWrt, including every gotcha encountered during the tintin deployment.

---
33 files changed, +3003/−292