### PR TITLE
fix(update): re-exec the pre-swap install path; survive exec failure;…

### DIFF
--- a/crates/cp-orchestrator/src/main.rs
+++ b/crates/cp-orchestrator/src/main.rs
@@ -35,6 +35,23 @@ use tiny_http as _;
 use utoipa as _;
 
 fn main() {
+    // Arguments must be handled before ANYTHING boots: a silently-ignored
+    // `--version` used to start the full server, bind the port, and shadow
+    // the real service (M6 e2e, 2026-07-16). Unknown arguments are a hard
+    // error for the same reason.
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "--version" | "-V" => {
+                println!("cp-orchestrator v{} (protocol v{})", env!("CARGO_PKG_VERSION"), cp_wire::PROTOCOL_VERSION);
+                return;
+            }
+            other => {
+                eprintln!("unknown argument: {other}");
+                std::process::exit(2);
+            }
+        }
+    }
+
     // Load .env files — override mode so file values always win over stale
     // shell env vars (e.g. BRAVE_API_KEY inherited from parent process).
     // Global loads second and overrides project-local — it's where the

--- a/crates/cp-orchestrator/src/runtime/update_scheduler.rs
+++ b/crates/cp-orchestrator/src/runtime/update_scheduler.rs
@@ -76,7 +76,7 @@ fn tick(backend: &Arc<Mutex<Backend>>, auth_db: &PathBuf, install: &PathBuf) -> 
             };
             stage_apply(&b.releases, b.auth.as_ref(), auth_db, install, &manifest.version)?;
             drop(b);
-            restart_self();
+            restart_self(install);
             Ok(current.clone())
         },
     );

--- a/crates/cp-orchestrator/src/services/releases/updater/apply.rs
+++ b/crates/cp-orchestrator/src/services/releases/updater/apply.rs
@@ -189,22 +189,23 @@ pub fn boot_reconcile(releases_dir: &Path, auth_db_path: &Path, install: &Path) 
     );
 }
 
-/// Re-exec the install path after a short delay (lets the HTTP reply flush).
-/// The process image is replaced on the same PID — no restart-burst consumed;
-/// falls back to `SIGTERM` so a supervisor can respawn us if `exec` fails.
-pub fn restart_self() {
+/// Re-exec `install` after a short delay (lets the HTTP reply flush). The
+/// caller passes the install path it resolved **before** the swap:
+/// `current_exe()` after the swap reads `/proc/self/exe`, which names the
+/// replaced inode (`… (deleted)`), not the staged binary.
+/// The process image is replaced on the same PID — no restart-burst consumed.
+/// If `exec` fails we exit non-zero so the supervisor respawns us: a
+/// self-inflicted `SIGTERM` counts as a *clean* stop under systemd's
+/// `Restart=on-failure` and would leave the service down.
+pub fn restart_self(install: &Path) {
     use std::os::unix::process::CommandExt as _;
-    let install = std::env::current_exe().ok();
+    let install = install.to_path_buf();
     let _restart = std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(200));
-        if let Some(exe) = install {
-            let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
-            let err = std::process::Command::new(&exe).args(&args).exec();
-            eprintln!("updater: exec of {} failed: {err}; falling back to SIGTERM", exe.display());
-        } else {
-            eprintln!("updater: current_exe() unavailable; falling back to SIGTERM");
-        }
-        let _sent = nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGTERM);
+        let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+        let err = std::process::Command::new(&install).args(&args).exec();
+        eprintln!("updater: exec of {} failed: {err}; exiting for supervisor respawn", install.display());
+        std::process::exit(1);
     });
 }
 

--- a/crates/cp-orchestrator/src/transport/rest/config/update.rs
+++ b/crates/cp-orchestrator/src/transport/rest/config/update.rs
@@ -131,7 +131,7 @@ pub(crate) fn update_apply(state: &Mutex<Backend>) -> HttpReply {
         }
     }
     eprintln!("updater: apply {current} → {} (admin request) — restarting", manifest.version);
-    restart_self();
+    restart_self(&install);
     HttpReply::ok(&serde_json::json!({ "status": "applying", "from": current, "to": manifest.version }))
 }
 

--- a/crates/cp-orchestrator/src/transport/rest/releases.rs
+++ b/crates/cp-orchestrator/src/transport/rest/releases.rs
@@ -362,8 +362,8 @@ pub(crate) fn deploy_fleet(state: &Mutex<Backend>, body: &[u8]) -> HttpReply {
 ///
 /// Re-exec works with **or without** a supervisor, and because the PID is
 /// preserved it never trips procd's crash-loop back-off. If `current_exe` or
-/// `exec` fails, we fall back to `SIGTERM` so a supervised host can still
-/// respawn the old way.
+/// `exec` fails, we exit non-zero so a supervised host respawns us (a
+/// self-inflicted `SIGTERM` is a *clean* stop to systemd and would not).
 pub(crate) fn restart_orchestrator(state: &Mutex<Backend>) -> HttpReply {
     use std::os::unix::process::CommandExt as _;
 
@@ -403,14 +403,15 @@ pub(crate) fn restart_orchestrator(state: &Mutex<Backend>) -> HttpReply {
             // `exec` only ever returns on failure — on success it never comes
             // back because the process image is replaced.
             let err = std::process::Command::new(&exe).args(&args).exec();
-            eprintln!("restart_orchestrator: exec of {} failed: {err}; falling back to SIGTERM", exe.display());
+            eprintln!("restart_orchestrator: exec of {} failed: {err}; exiting for supervisor respawn", exe.display());
         } else {
-            eprintln!("restart_orchestrator: current_exe() unavailable; falling back to SIGTERM");
+            eprintln!("restart_orchestrator: current_exe() unavailable; exiting for supervisor respawn");
         }
 
-        // Fallback: if re-exec did not take over, signal ourselves so a
-        // supervisor (procd) can respawn the service the old way.
-        let _sent = nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGTERM);
+        // Fallback: exit non-zero so the supervisor respawns us. A
+        // self-inflicted SIGTERM counts as a *clean* stop under systemd's
+        // `Restart=on-failure` and would leave the service down.
+        std::process::exit(1);
     });
 
     HttpReply::ok(&serde_json::json!({

--- a/deploy/ansible/templates/context-pilot.service.j2
+++ b/deploy/ansible/templates/context-pilot.service.j2
@@ -34,7 +34,11 @@ EnvironmentFile=-{{ cp_root }}/seed.env
 EnvironmentFile=-{{ cp_root }}/providers.env
 ExecStartPre=/bin/mkdir -p {{ cp_root }}/home
 ExecStart={{ cp_root }}/bin/cp-orchestrator
-Restart=on-failure
+# `always`, not `on-failure`: the self-updater may end its old process with a
+# clean-looking exit (its exec fallback), and `on-failure` would leave the box
+# headless (M6 e2e, 2026-07-16). `systemctl stop` still stops for good —
+# systemd never auto-restarts after an explicit stop.
+Restart=always
 RestartSec=5
 
 [Install]


### PR DESCRIPTION
… --version flag

Three fixes from the first OTA e2e on the box (M6, v0.1.0 → v0.2.12):

1. restart_self() resolved current_exe() AFTER the binary swap, which on Linux yields the replaced inode's name ("… (deleted)") — exec then fails ENOENT. It now takes the install path the caller resolved before the swap (the legacy restart_orchestrator already did this).

2. The exec-failure fallback was a self-inflicted SIGTERM, which systemd treats as a CLEAN stop — Restart=on-failure never respawned and the box stayed headless. Fallback is now exit(1), and the Ansible unit moves to Restart=always (same fix in the legacy restart_orchestrator fallback).

3. cp-orchestrator ignored unknown CLI flags and booted the full server: a diagnostic `--version` bound :7878, shadowed the service, made every subsequent boot fail Address-in-use, and drove the boot-counter into rolling back a healthy update. --version/-V now prints and exits; unknown arguments are a hard error (exit 2).

## Description

Brief description of the changes in this PR.

Fixes #(issue number)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)

## Changes Made

- 
- 
- 

## Testing

Describe how you tested your changes:

- [ ] Ran `cargo build --release`
- [ ] Ran `cargo test`
- [ ] Manually tested the feature/fix
- [ ] Tested on: [OS/terminal]

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Reviewers

Reviewers are auto-assigned via [CODEOWNERS](/.github/CODEOWNERS) based on files changed.

If you need a specific reviewer, mention them here: 

## Additional Notes

<!-- Any additional context for reviewers -->
