### PR TITLE
feat(update): nightly OTA channel + cockpit opt-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,10 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    # Expose the computed tag so the manifest job pins the exact same release
+    # (no re-derivation, no drift between the release and its manifest).
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -259,29 +263,33 @@ jobs:
           make_latest: true
 
   # ── Signed update manifest (update-policy §5.3–§5.5) ────────────────────
-  # Only a REAL `v*` tag push promotes the fleet: it publishes `stable.json` +
-  # a detached minisign signature on the `channels` branch. Auto-releases from
-  # master pushes (v<version>-<sha>) build + release but never touch the
-  # channel — tagging IS the fleet release act (update-policy v3 decision 2).
+  # Two channels, one job, published to the orphan `channels` branch:
+  #   • a REAL `v*` tag push   → `stable.json`  (promotes the fleet; 90-day expiry)
+  #   • a push to `master`     → `nightly.json` (tip-of-master; 14-day expiry)
+  # Both sign a detached minisign signature. Tagging remains the *stable* fleet
+  # release act (update-policy v3 decision 2); nightly is the opt-in fast lane.
   #
   # The manifest pins all five published arches: the three Linux appliance
-  # targets (Photonicat fleet) plus both macOS targets, so a macOS dev box
-  # running the orchestrator can self-update too (arch match via KNOWN_ARCHS).
+  # targets (Photonicat fleet — pcat is `linux-aarch64-musl`) plus both macOS
+  # targets, so a macOS dev box running the orchestrator can self-update too
+  # (arch match via KNOWN_ARCHS). Each box picks its own artifact.
   manifest:
-    name: Publish signed stable manifest
+    name: Publish signed channel manifest
     needs: release
-    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     env:
-      TAG: ${{ github.ref_name }}
+      # Same tag the release job published — no re-derivation.
+      TAG: ${{ needs.release.outputs.tag }}
       REPO: ${{ github.repository }}
+      # tag push → stable channel / 90-day freshness; master push → nightly
+      # channel / 14-day freshness (republished on every master commit).
+      CHANNEL: ${{ github.ref_type == 'tag' && 'stable' || 'nightly' }}
+      EXPIRES_DAYS: ${{ github.ref_type == 'tag' && '90' || '14' }}
       # Oldest running version this release can be applied from (update-policy
       # §5.6 anti-rollback floor). Bump deliberately when a migration or
-      # protocol break makes direct jumps unsafe.
+      # protocol break makes direct jumps unsafe. Nightly ignores this floor on
+      # the box (head-tracking), but the field stays for schema completeness.
       MIN_FROM: "v0.1.0"
-      # Manifest freshness horizon (§5.6): a manifest older than this is
-      # treated as a stale replay by the box.
-      EXPIRES_DAYS: "90"
     steps:
       - uses: actions/checkout@v4
 
@@ -302,7 +310,7 @@ jobs:
           done
           sha256sum assets/*.tar.gz
 
-      - name: Generate stable.json
+      - name: Generate channel manifest
         run: |
           released_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           expires_at=$(date -u -d "+${EXPIRES_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)
@@ -316,59 +324,76 @@ jobs:
               '. + {($a): {url: $u, sha256: $s, size: $z}}' <<<"$artifacts")
           done
           jq -n \
+            --arg channel "$CHANNEL" \
             --arg version "$TAG" \
             --arg released_at "$released_at" \
             --arg expires_at "$expires_at" \
             --arg min_from "$MIN_FROM" \
             --arg notes_url "https://github.com/${REPO}/releases/tag/${TAG}" \
             --argjson artifacts "$artifacts" \
-            '{schema: 1, channel: "stable", version: $version,
+            '{schema: 1, channel: $channel, version: $version,
               released_at: $released_at, expires_at: $expires_at,
               min_from: $min_from, notes_url: $notes_url,
-              artifacts: $artifacts}' > stable.json
-          cat stable.json
+              artifacts: $artifacts}' > "${CHANNEL}.json"
+          cat "${CHANNEL}.json"
 
-      # Gate the exact contract the box relies on before signing anything.
+      # Gate the exact contract the box relies on before signing anything — all
+      # five arches must be pinned (pcat's musl lane included).
       - name: Check manifest contract
         run: |
-          jq -e '.schema and .version and .artifacts["linux-aarch64"].sha256 and .artifacts["linux-aarch64-musl"].sha256 and .artifacts["linux-x86_64"].sha256 and .artifacts["macos-aarch64"].sha256 and .artifacts["macos-x86_64"].sha256' stable.json
-          test "$(jq -r .version stable.json)" = "$TAG"
+          jq -e '.schema and .version and (.channel == env.CHANNEL) and (.artifacts | keys | length == 5) and .artifacts["linux-aarch64"].sha256 and .artifacts["linux-aarch64-musl"].sha256 and .artifacts["linux-x86_64"].sha256 and .artifacts["macos-aarch64"].sha256 and .artifacts["macos-x86_64"].sha256' "${CHANNEL}.json"
+          test "$(jq -r .version "${CHANNEL}.json")" = "$TAG"
 
-      - name: Sign stable.json (minisign)
+      - name: Sign channel manifest (minisign)
         env:
           MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
         run: |
           umask 077
           printf '%s\n' "$MINISIGN_SECRET_KEY" > minisign.key
-          minisign -S -s minisign.key -m stable.json -x stable.json.minisig \
-            -t "channel=stable version=${TAG}"
+          minisign -S -s minisign.key -m "${CHANNEL}.json" -x "${CHANNEL}.json.minisig" \
+            -t "channel=${CHANNEL} version=${TAG}"
           rm -f minisign.key
           # Verify with the embedded public key — the signature must check out
           # against the exact trust anchor shipped in the orchestrator.
           pubkey=$(grep -o '"RW[A-Za-z0-9+/=]*"' \
             crates/cp-orchestrator/src/services/releases/signing.rs | tr -d '"')
-          minisign -Vm stable.json -x stable.json.minisig -P "$pubkey"
+          minisign -Vm "${CHANNEL}.json" -x "${CHANNEL}.json.minisig" -P "$pubkey"
 
-      # Idempotent, dedicated commit on the `channels` branch (created orphan
-      # on first publish). Re-running the job for the same content is a no-op.
+      # Idempotent, dedicated commit on the `channels` branch (created orphan on
+      # first publish). Only this channel's two files are staged, so stable and
+      # nightly coexist. A tag push and a master push have DIFFERENT concurrency
+      # groups (build-release-${{ github.ref }}) and can run at once, both
+      # branching from the same `origin/channels` tip — so re-fetch + re-apply on
+      # a rejected push instead of losing the update.
       - name: Push manifest to channels branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code origin channels >/dev/null 2>&1; then
-            git fetch origin channels
-            git worktree add channels-wt origin/channels
-            (cd channels-wt && git checkout -B channels)
-          else
-            git worktree add --detach channels-wt
-            (cd channels-wt && git checkout --orphan channels && git rm -rfq . || true)
-          fi
-          cp stable.json stable.json.minisig channels-wt/
-          cd channels-wt
-          git add stable.json stable.json.minisig
-          if git diff --cached --quiet; then
-            echo "channels already up to date — nothing to push"
-          else
-            git commit -m "channels: stable → ${TAG}"
-            git push origin channels
-          fi
+          cp "${CHANNEL}.json" "${CHANNEL}.json.minisig" /tmp/
+          for attempt in 1 2 3 4 5; do
+            rm -rf channels-wt
+            if git ls-remote --exit-code origin channels >/dev/null 2>&1; then
+              git fetch origin channels
+              git worktree add channels-wt origin/channels
+              (cd channels-wt && git checkout -B channels)
+            else
+              git worktree add --detach channels-wt
+              (cd channels-wt && git checkout --orphan channels && git rm -rfq . || true)
+            fi
+            cp "/tmp/${CHANNEL}.json" "/tmp/${CHANNEL}.json.minisig" channels-wt/
+            cd channels-wt
+            git add "${CHANNEL}.json" "${CHANNEL}.json.minisig"
+            if git diff --cached --quiet; then
+              echo "channels already up to date — nothing to push"
+              break
+            fi
+            git commit -m "channels: ${CHANNEL} → ${TAG}"
+            if git push origin channels; then
+              echo "pushed ${CHANNEL} manifest on attempt ${attempt}"
+              break
+            fi
+            echo "push rejected (concurrent update?) — retrying (${attempt}/5)"
+            cd ..
+            git worktree remove --force channels-wt
+            sleep $((RANDOM % 5 + 2))
+          done

--- a/crates/cp-orchestrator/src/runtime/update_scheduler.rs
+++ b/crates/cp-orchestrator/src/runtime/update_scheduler.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use crate::services::ReleaseStore;
 use crate::services::releases::updater::{
-    UpdateEvaluation, check_stable, download_artifact, restart_self, scheduler, stage_apply,
+    UpdateEvaluation, check_channel, download_artifact, restart_self, scheduler, stage_apply,
 };
 use crate::transport::Backend;
 // The process-wide apply gate is shared with `POST /api/update/apply` so the
@@ -51,6 +51,8 @@ fn tick(backend: &Arc<Mutex<Backend>>, auth_db: &PathBuf, install: &PathBuf) -> 
     let interval_hours = b.releases.poll_interval_hours().max(1);
     let arch = b.releases.arch().to_owned();
     let releases_dir = b.releases.dir().to_path_buf();
+    let channel = b.releases.channel().to_owned();
+    let crossgrade = b.releases.pending_channel_switch();
     let current = scheduler::current_version(&b.releases);
     drop(b);
 
@@ -61,7 +63,15 @@ fn tick(backend: &Arc<Mutex<Backend>>, auth_db: &PathBuf, install: &PathBuf) -> 
         now_minutes,
         &APPLY_IN_FLIGHT,
         || {
-            check_stable(&releases_dir, &current).map(|eval| match eval {
+            let result = check_channel(&releases_dir, &channel, &current, crossgrade);
+            // A verified answer on the new channel retires the crossgrade window
+            // (mirrors the REST check handler).
+            if result.is_ok() {
+                if let Ok(mut b) = backend.lock() {
+                    b.releases.clear_pending_switch();
+                }
+            }
+            result.map(|eval| match eval {
                 UpdateEvaluation::Available(manifest) => Some(manifest),
                 UpdateEvaluation::UpToDate => None,
             })

--- a/crates/cp-orchestrator/src/services/releases/channel.rs
+++ b/crates/cp-orchestrator/src/services/releases/channel.rs
@@ -1,0 +1,57 @@
+//! OTA channel selection for the [`ReleaseStore`] — which channel the box
+//! follows (`stable`/`nightly`) and the one-shot "crossgrade" flag an explicit
+//! admin switch arms so the next check adopts the target channel's head
+//! regardless of version ordering. This matters because nightly tags are
+//! `v0.1.0-<sha>`, whose `semver_sort_key` sorts *below* a stable `v0.2.x`, so a
+//! plain monotonic comparison would refuse the move as a rollback.
+
+use super::ReleaseStore;
+use super::updater::UpdateState;
+
+impl ReleaseStore {
+    /// The channel this box follows (`stable` or `nightly`).
+    #[must_use]
+    pub fn channel(&self) -> &str {
+        &self.config.channel
+    }
+
+    /// Whether an admin channel switch is awaiting its first check — the next
+    /// evaluation adopts the new channel's head regardless of version ordering.
+    #[must_use]
+    pub fn pending_channel_switch(&self) -> bool {
+        self.config.pending_channel_switch
+    }
+
+    /// Switch the channel this box follows and persist. Arms the crossgrade
+    /// flag and drops the now-stale "update available" hint (it pertained to
+    /// the old channel) so the pane doesn't offer a foreign version until the
+    /// next check on the new channel resolves.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `channel` is not one of `stable` / `nightly`.
+    pub fn set_channel(&mut self, channel: &str) -> Result<(), String> {
+        if !matches!(channel, "stable" | "nightly") {
+            return Err(format!("unknown channel {channel:?} (expected stable or nightly)"));
+        }
+        if self.config.channel == channel {
+            return Ok(());
+        }
+        self.config.channel = channel.to_owned();
+        self.config.pending_channel_switch = true;
+        self.persist();
+        let mut st = UpdateState::load(&self.dir);
+        st.available = None;
+        st.available_notes_url = None;
+        st.save(&self.dir);
+        Ok(())
+    }
+
+    /// Clear the crossgrade flag once a check on the new channel has resolved.
+    pub fn clear_pending_switch(&mut self) {
+        if self.config.pending_channel_switch {
+            self.config.pending_channel_switch = false;
+            self.persist();
+        }
+    }
+}

--- a/crates/cp-orchestrator/src/services/releases/config.rs
+++ b/crates/cp-orchestrator/src/services/releases/config.rs
@@ -118,9 +118,15 @@ pub(crate) struct ReleaseConfig {
     /// Auto-update posture (default `auto` — update-policy v3 decision 3).
     #[serde(default)]
     pub(crate) update_mode: UpdateMode,
-    /// Channel this box follows (only `stable` is published today).
+    /// Channel this box follows (`stable` or `nightly`).
     #[serde(default = "default_channel")]
     pub(crate) channel: String,
+    /// Set the moment an admin switches `channel`; makes the next check adopt
+    /// the new channel's head regardless of version ordering (a `stable`
+    /// `v0.2.x` box moving to a `nightly` `v0.1.0-<sha>` would otherwise read as
+    /// a downgrade). Cleared once a check on the new channel resolves.
+    #[serde(default)]
+    pub(crate) pending_channel_switch: bool,
     /// Hours between channel polls (a boot poll always happens too).
     #[serde(default = "default_poll_interval_hours")]
     pub(crate) poll_interval_hours: u32,
@@ -137,6 +143,7 @@ impl Default for ReleaseConfig {
             active_tag: None,
             update_mode: UpdateMode::default(),
             channel: default_channel(),
+            pending_channel_switch: false,
             poll_interval_hours: default_poll_interval_hours(),
             window: MaintenanceWindow::default(),
         }

--- a/crates/cp-orchestrator/src/services/releases/mod.rs
+++ b/crates/cp-orchestrator/src/services/releases/mod.rs
@@ -196,10 +196,50 @@ impl ReleaseStore {
         self.persist();
     }
 
-    /// The channel this box follows (`stable` today).
+    /// The channel this box follows (`stable` or `nightly`).
     #[must_use]
     pub fn channel(&self) -> &str {
         &self.config.channel
+    }
+
+    /// Whether an admin channel switch is awaiting its first check — the next
+    /// evaluation adopts the new channel's head regardless of version ordering.
+    #[must_use]
+    pub fn pending_channel_switch(&self) -> bool {
+        self.config.pending_channel_switch
+    }
+
+    /// Switch the channel this box follows and persist. Arms the crossgrade
+    /// flag and drops the now-stale "update available" hint (it pertained to
+    /// the old channel) so the pane doesn't offer a foreign version until the
+    /// next check on the new channel resolves.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `channel` is not one of `stable` / `nightly`.
+    pub fn set_channel(&mut self, channel: &str) -> Result<(), String> {
+        if !matches!(channel, "stable" | "nightly") {
+            return Err(format!("unknown channel {channel:?} (expected stable or nightly)"));
+        }
+        if self.config.channel == channel {
+            return Ok(());
+        }
+        self.config.channel = channel.to_owned();
+        self.config.pending_channel_switch = true;
+        self.persist();
+        let mut st = updater::UpdateState::load(&self.dir);
+        st.available = None;
+        st.available_notes_url = None;
+        st.save(&self.dir);
+        Ok(())
+    }
+
+    /// Clear the crossgrade flag once a check on the new channel has resolved.
+    pub fn clear_pending_switch(&mut self) {
+        if self.config.pending_channel_switch {
+            self.config.pending_channel_switch = false;
+            self.persist();
+        }
     }
 
     /// Hours between channel polls.

--- a/crates/cp-orchestrator/src/services/releases/mod.rs
+++ b/crates/cp-orchestrator/src/services/releases/mod.rs
@@ -37,6 +37,10 @@ mod config;
 use config::ReleaseConfig;
 pub use config::{MaintenanceWindow, UpdateMode};
 
+/// OTA channel selection (`stable`/`nightly`) + the crossgrade flag — see
+/// [`channel`].
+mod channel;
+
 // ── Public types ────────────────────────────────────────────────────────
 
 /// A locally downloaded release (tag + binary presence).
@@ -196,51 +200,8 @@ impl ReleaseStore {
         self.persist();
     }
 
-    /// The channel this box follows (`stable` or `nightly`).
-    #[must_use]
-    pub fn channel(&self) -> &str {
-        &self.config.channel
-    }
-
-    /// Whether an admin channel switch is awaiting its first check — the next
-    /// evaluation adopts the new channel's head regardless of version ordering.
-    #[must_use]
-    pub fn pending_channel_switch(&self) -> bool {
-        self.config.pending_channel_switch
-    }
-
-    /// Switch the channel this box follows and persist. Arms the crossgrade
-    /// flag and drops the now-stale "update available" hint (it pertained to
-    /// the old channel) so the pane doesn't offer a foreign version until the
-    /// next check on the new channel resolves.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `channel` is not one of `stable` / `nightly`.
-    pub fn set_channel(&mut self, channel: &str) -> Result<(), String> {
-        if !matches!(channel, "stable" | "nightly") {
-            return Err(format!("unknown channel {channel:?} (expected stable or nightly)"));
-        }
-        if self.config.channel == channel {
-            return Ok(());
-        }
-        self.config.channel = channel.to_owned();
-        self.config.pending_channel_switch = true;
-        self.persist();
-        let mut st = updater::UpdateState::load(&self.dir);
-        st.available = None;
-        st.available_notes_url = None;
-        st.save(&self.dir);
-        Ok(())
-    }
-
-    /// Clear the crossgrade flag once a check on the new channel has resolved.
-    pub fn clear_pending_switch(&mut self) {
-        if self.config.pending_channel_switch {
-            self.config.pending_channel_switch = false;
-            self.persist();
-        }
-    }
+    // Channel selection (`channel`, `set_channel`, the crossgrade flag) lives in
+    // the sibling `channel` module — see `channel.rs`.
 
     /// Hours between channel polls.
     #[must_use]

--- a/crates/cp-orchestrator/src/services/releases/tests.rs
+++ b/crates/cp-orchestrator/src/services/releases/tests.rs
@@ -92,6 +92,45 @@ fn update_config_roundtrip() {
     drop(std::fs::remove_dir_all(&dir));
 }
 
+/// A channel switch validates its input, arms the crossgrade flag, clears the
+/// stale "available" hint, and round-trips through persist + reload; clearing
+/// the flag persists too.
+#[test]
+fn store_set_channel_roundtrip() {
+    let dir = std::env::temp_dir().join(format!("cp-rel-chan-{}", std::process::id()));
+    drop(std::fs::create_dir_all(&dir));
+    let releases = dir.join("releases");
+
+    let mut store = ReleaseStore::load(releases.clone());
+    assert_eq!(store.channel(), "stable", "default channel");
+    assert!(!store.pending_channel_switch());
+
+    // A stale availability hint from the old channel must be dropped on switch.
+    let mut st = updater::UpdateState::load(&releases);
+    st.available = Some("v9.9.9".to_owned());
+    st.save(&releases);
+
+    assert!(store.set_channel("bogus").is_err(), "unknown channel refused");
+    store.set_channel("nightly").expect("nightly accepted");
+    assert_eq!(store.channel(), "nightly");
+    assert!(store.pending_channel_switch(), "switch arms the crossgrade flag");
+    assert!(updater::UpdateState::load(&releases).available.is_none(), "stale available cleared");
+
+    // Persisted: a reload sees the switch and the armed flag.
+    let reloaded = ReleaseStore::load(releases.clone());
+    assert_eq!(reloaded.channel(), "nightly");
+    assert!(reloaded.pending_channel_switch());
+
+    // Clearing the flag persists; a no-op re-set of the same channel is inert.
+    store.clear_pending_switch();
+    assert!(!store.pending_channel_switch());
+    store.set_channel("nightly").expect("same channel is a no-op");
+    assert!(!store.pending_channel_switch(), "re-setting the current channel does not re-arm");
+    assert!(!ReleaseStore::load(releases).pending_channel_switch(), "clear persisted");
+
+    drop(std::fs::remove_dir_all(&dir));
+}
+
 #[test]
 fn store_select_rejects_missing() {
     let dir = std::env::temp_dir().join(format!("cp-rel-sel-{}", std::process::id()));

--- a/crates/cp-orchestrator/src/services/releases/updater/mod.rs
+++ b/crates/cp-orchestrator/src/services/releases/updater/mod.rs
@@ -39,13 +39,14 @@ fn channel_url(file: &str) -> String {
     format!("https://raw.githubusercontent.com/{}/channels/{file}", super::GITHUB_REPO)
 }
 
-/// Fetch the `stable` channel's manifest bytes + detached signature.
+/// Fetch a channel's manifest bytes + detached signature (`{channel}.json` +
+/// `{channel}.json.minisig`).
 ///
 /// # Errors
 ///
 /// Returns an error on network failure or a non-success HTTP status. No
 /// verification happens here — callers hand the pair to [`evaluate_manifest`].
-pub fn fetch_stable_manifest() -> Result<(Vec<u8>, String), String> {
+pub fn fetch_channel_manifest(channel: &str) -> Result<(Vec<u8>, String), String> {
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
@@ -59,14 +60,16 @@ pub fn fetch_stable_manifest() -> Result<(Vec<u8>, String), String> {
         }
         resp.bytes().map(|b| b.to_vec()).map_err(|e| format!("read {url}: {e}"))
     };
-    let manifest = fetch("stable.json")?;
-    let sig_bytes = fetch("stable.json.minisig")?;
+    let manifest = fetch(&format!("{channel}.json"))?;
+    let sig_bytes = fetch(&format!("{channel}.json.minisig"))?;
     let sig = String::from_utf8(sig_bytes).map_err(|e| format!("signature is not UTF-8: {e}"))?;
     Ok((manifest, sig))
 }
 
-/// One full **check** (read-only): fetch the stable manifest, verify it, and
-/// record the outcome in `update-state.json` under `releases_dir`.
+/// One full **check** (read-only): fetch the configured channel's manifest,
+/// verify it, and record the outcome in `update-state.json` under
+/// `releases_dir`. `allow_crossgrade` is set right after an explicit channel
+/// switch so the box adopts the new channel's head regardless of version order.
 ///
 /// A failed signature / freshness / anti-rollback check returns `Err` and the
 /// last-known state is kept (`available` is cleared only on a *verified*
@@ -75,12 +78,18 @@ pub fn fetch_stable_manifest() -> Result<(Vec<u8>, String), String> {
 /// # Errors
 ///
 /// Returns an error string on fetch failure or any failed verification.
-pub fn check_stable(releases_dir: &Path, current: &str) -> Result<UpdateEvaluation, String> {
+pub fn check_channel(
+    releases_dir: &Path,
+    channel: &str,
+    current: &str,
+    allow_crossgrade: bool,
+) -> Result<UpdateEvaluation, String> {
     let mut st = UpdateState::load(releases_dir);
     st.last_check_ms = Some(state::now_ms());
 
-    let outcome = fetch_stable_manifest().and_then(|(bytes, sig)| {
-        evaluate_manifest(&bytes, &sig, current, state::now_epoch_secs()).map_err(|e| e.to_string())
+    let outcome = fetch_channel_manifest(channel).and_then(|(bytes, sig)| {
+        evaluate_manifest(&bytes, &sig, current, state::now_epoch_secs(), channel, allow_crossgrade)
+            .map_err(|e| e.to_string())
     });
     match &outcome {
         Ok(UpdateEvaluation::Available(manifest)) => {
@@ -114,12 +123,14 @@ pub fn check_and_prepare<D>(
     signature: &str,
     current: &str,
     now_epoch_secs: u64,
+    expected_channel: &str,
+    allow_crossgrade: bool,
     download: D,
 ) -> Result<Option<Manifest>, String>
 where
     D: FnOnce(&Manifest) -> Result<(), String>,
 {
-    match evaluate_manifest(manifest_bytes, signature, current, now_epoch_secs) {
+    match evaluate_manifest(manifest_bytes, signature, current, now_epoch_secs, expected_channel, allow_crossgrade) {
         Ok(UpdateEvaluation::Available(manifest)) => {
             download(&manifest)?;
             Ok(Some(manifest))

--- a/crates/cp-orchestrator/src/services/releases/updater/tests.rs
+++ b/crates/cp-orchestrator/src/services/releases/updater/tests.rs
@@ -103,87 +103,9 @@ fn updater_verify() {
     );
 }
 
-/// Bare manifest for the pure-decision tests — [`evaluate_parsed`] ignores
-/// artifacts, so only channel/version/expires/min_from need to be real.
-fn decision_manifest(channel: &str, version: &str, expires_at: &str, min_from: &str) -> super::super::Manifest {
-    super::super::Manifest {
-        schema: 1,
-        channel: channel.to_owned(),
-        version: version.to_owned(),
-        released_at: "2026-07-10T12:00:00Z".to_owned(),
-        expires_at: expires_at.to_owned(),
-        min_from: min_from.to_owned(),
-        notes_url: String::new(),
-        artifacts: std::collections::BTreeMap::new(),
-    }
-}
-
-/// The channel-aware "is-newer" matrix (nightly head-tracking, the
-/// channel-equality guard, and forced adoption on a switch), exercised on
-/// already-parsed manifests — the fixtures are signed with the real release key
-/// so a nightly one cannot be minted, and this logic sits after the signature.
-#[test]
-fn updater_channel_decisions() {
-    use super::VerifyError;
-    use super::verify::evaluate_parsed;
-
-    /// Fresh well past `NOW` (2027-01-15).
-    const FRESH: &str = "2126-01-01T00:00:00Z";
-
-    // Nightly head-tracking: a different sha at the same (M,m,p) is an update…
-    let m = decision_manifest("nightly", "v0.1.0-def5678", FRESH, "v0.1.0");
-    assert!(
-        matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Ok(UpdateEvaluation::Available(_))),
-        "a new nightly sha at the same semver must be Available"
-    );
-    // …and the identical version is UpToDate (no perpetual re-apply).
-    let m = decision_manifest("nightly", "v0.1.0-abc1234", FRESH, "v0.1.0");
-    assert!(
-        matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Ok(UpdateEvaluation::UpToDate)),
-        "the same nightly build is up to date"
-    );
-
-    // Nightly ignores the min_from floor (head-tracking drops anti-rollback).
-    let m = decision_manifest("nightly", "v0.1.0-def5678", FRESH, "v9.9.9");
-    assert!(
-        matches!(evaluate_parsed(m, "v0.0.1-old", NOW, "nightly", false), Ok(UpdateEvaluation::Available(_))),
-        "nightly skips the min_from floor"
-    );
-
-    // Freshness still bites on nightly: an expired manifest is a stale replay.
-    let m = decision_manifest("nightly", "v0.1.0-def5678", "2020-01-01T00:00:00Z", "v0.1.0");
-    assert!(
-        matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Err(VerifyError::Expired { .. })),
-        "an expired nightly manifest is refused"
-    );
-
-    // Channel-equality guard: a signed *stable* manifest served where nightly
-    // is expected is refused — the only guard left on the head-tracking path.
-    let m = decision_manifest("stable", "v0.2.12", FRESH, "v0.1.0");
-    assert!(
-        matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Err(VerifyError::ChannelMismatch { .. })),
-        "a cross-channel manifest must be refused"
-    );
-
-    // Forced adoption on an explicit switch: crossgrade bypasses the semver
-    // anti-rollback that would otherwise reject a lower stable version.
-    let m = decision_manifest("stable", "v0.1.0", FRESH, "v0.1.0");
-    assert!(
-        matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", false), Err(VerifyError::Rollback { .. })),
-        "without a switch a lower version is a rollback"
-    );
-    let m = decision_manifest("stable", "v0.1.0", FRESH, "v0.1.0");
-    assert!(
-        matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", true), Ok(UpdateEvaluation::Available(_))),
-        "an explicit switch adopts the target head regardless of version order"
-    );
-    // A crossgrade to the identical version is still a no-op.
-    let m = decision_manifest("stable", "v0.2.0", FRESH, "v0.1.0");
-    assert!(
-        matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", true), Ok(UpdateEvaluation::UpToDate)),
-        "crossgrade to the same version is up to date"
-    );
-}
+// The channel-aware "is-newer" matrix (nightly head-tracking, the channel
+// guard, forced adoption on a switch) is unit-tested next to `evaluate_parsed`
+// in `verify.rs` — it needs no signed fixture, so it lives with the code.
 
 /// V3.1b — the download hook is provably never invoked when any verification
 /// fails; it runs exactly once on a verified available update.

--- a/crates/cp-orchestrator/src/services/releases/updater/tests.rs
+++ b/crates/cp-orchestrator/src/services/releases/updater/tests.rs
@@ -39,7 +39,7 @@ fn temp_dir(label: &str) -> std::path::PathBuf {
 #[test]
 fn updater_verify() {
     // Valid manifest, older box → Available(v9.9.9).
-    match evaluate_manifest(VALID_JSON, VALID_SIG, "v0.3.0", NOW) {
+    match evaluate_manifest(VALID_JSON, VALID_SIG, "v0.3.0", NOW, "stable", false) {
         Ok(UpdateEvaluation::Available(m)) => assert_eq!(m.version, "v9.9.9"),
         other => panic!("valid manifest must be Available: {other:?}"),
     }
@@ -49,33 +49,45 @@ fn updater_verify() {
     let pos = tampered.iter().position(|&b| b == b'9').expect("a '9' in the fixture");
     tampered[pos] = b'8';
     assert!(
-        matches!(evaluate_manifest(&tampered, VALID_SIG, "v0.3.0", NOW), Err(super::VerifyError::Signature(_))),
+        matches!(
+            evaluate_manifest(&tampered, VALID_SIG, "v0.3.0", NOW, "stable", false),
+            Err(super::VerifyError::Signature(_))
+        ),
         "tampered manifest bytes must fail the signature check"
     );
 
     // A corrupted signature blob → signature failure.
     let bad_sig = VALID_SIG.replace('A', "B");
     assert!(
-        matches!(evaluate_manifest(VALID_JSON, &bad_sig, "v0.3.0", NOW), Err(super::VerifyError::Signature(_))),
+        matches!(
+            evaluate_manifest(VALID_JSON, &bad_sig, "v0.3.0", NOW, "stable", false),
+            Err(super::VerifyError::Signature(_))
+        ),
         "tampered signature must fail"
     );
 
     // Correctly signed but expired → freshness rejection (stale replay).
     assert!(
-        matches!(evaluate_manifest(EXPIRED_JSON, EXPIRED_SIG, "v0.3.0", NOW), Err(super::VerifyError::Expired { .. })),
+        matches!(
+            evaluate_manifest(EXPIRED_JSON, EXPIRED_SIG, "v0.3.0", NOW, "stable", false),
+            Err(super::VerifyError::Expired { .. })
+        ),
         "expired manifest must be rejected"
     );
 
     // Anti-rollback: offered (v9.9.9) below the running version.
     assert!(
-        matches!(evaluate_manifest(VALID_JSON, VALID_SIG, "v10.0.0", NOW), Err(super::VerifyError::Rollback { .. })),
+        matches!(
+            evaluate_manifest(VALID_JSON, VALID_SIG, "v10.0.0", NOW, "stable", false),
+            Err(super::VerifyError::Rollback { .. })
+        ),
         "manifest older than the running version must be rejected"
     );
 
     // min_from floor: a box on v0.1.0 may not jump (min_from is v0.2.0).
     assert!(
         matches!(
-            evaluate_manifest(VALID_JSON, VALID_SIG, "v0.1.0", NOW),
+            evaluate_manifest(VALID_JSON, VALID_SIG, "v0.1.0", NOW, "stable", false),
             Err(super::VerifyError::TooOldForJump { .. })
         ),
         "a box below min_from must be refused"
@@ -83,8 +95,93 @@ fn updater_verify() {
 
     // Same version → UpToDate (not an error, not an update).
     assert!(
-        matches!(evaluate_manifest(VALID_JSON, VALID_SIG, "v9.9.9", NOW), Ok(UpdateEvaluation::UpToDate)),
+        matches!(
+            evaluate_manifest(VALID_JSON, VALID_SIG, "v9.9.9", NOW, "stable", false),
+            Ok(UpdateEvaluation::UpToDate)
+        ),
         "equal version is up to date"
+    );
+}
+
+/// Bare manifest for the pure-decision tests — [`evaluate_parsed`] ignores
+/// artifacts, so only channel/version/expires/min_from need to be real.
+fn decision_manifest(channel: &str, version: &str, expires_at: &str, min_from: &str) -> super::super::Manifest {
+    super::super::Manifest {
+        schema: 1,
+        channel: channel.to_owned(),
+        version: version.to_owned(),
+        released_at: "2026-07-10T12:00:00Z".to_owned(),
+        expires_at: expires_at.to_owned(),
+        min_from: min_from.to_owned(),
+        notes_url: String::new(),
+        artifacts: std::collections::BTreeMap::new(),
+    }
+}
+
+/// The channel-aware "is-newer" matrix (nightly head-tracking, the
+/// channel-equality guard, and forced adoption on a switch), exercised on
+/// already-parsed manifests — the fixtures are signed with the real release key
+/// so a nightly one cannot be minted, and this logic sits after the signature.
+#[test]
+fn updater_channel_decisions() {
+    use super::VerifyError;
+    use super::verify::evaluate_parsed;
+
+    /// Fresh well past `NOW` (2027-01-15).
+    const FRESH: &str = "2126-01-01T00:00:00Z";
+
+    // Nightly head-tracking: a different sha at the same (M,m,p) is an update…
+    let m = decision_manifest("nightly", "v0.1.0-def5678", FRESH, "v0.1.0");
+    assert!(
+        matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Ok(UpdateEvaluation::Available(_))),
+        "a new nightly sha at the same semver must be Available"
+    );
+    // …and the identical version is UpToDate (no perpetual re-apply).
+    let m = decision_manifest("nightly", "v0.1.0-abc1234", FRESH, "v0.1.0");
+    assert!(
+        matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Ok(UpdateEvaluation::UpToDate)),
+        "the same nightly build is up to date"
+    );
+
+    // Nightly ignores the min_from floor (head-tracking drops anti-rollback).
+    let m = decision_manifest("nightly", "v0.1.0-def5678", FRESH, "v9.9.9");
+    assert!(
+        matches!(evaluate_parsed(m, "v0.0.1-old", NOW, "nightly", false), Ok(UpdateEvaluation::Available(_))),
+        "nightly skips the min_from floor"
+    );
+
+    // Freshness still bites on nightly: an expired manifest is a stale replay.
+    let m = decision_manifest("nightly", "v0.1.0-def5678", "2020-01-01T00:00:00Z", "v0.1.0");
+    assert!(
+        matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Err(VerifyError::Expired { .. })),
+        "an expired nightly manifest is refused"
+    );
+
+    // Channel-equality guard: a signed *stable* manifest served where nightly
+    // is expected is refused — the only guard left on the head-tracking path.
+    let m = decision_manifest("stable", "v0.2.12", FRESH, "v0.1.0");
+    assert!(
+        matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Err(VerifyError::ChannelMismatch { .. })),
+        "a cross-channel manifest must be refused"
+    );
+
+    // Forced adoption on an explicit switch: crossgrade bypasses the semver
+    // anti-rollback that would otherwise reject a lower stable version.
+    let m = decision_manifest("stable", "v0.1.0", FRESH, "v0.1.0");
+    assert!(
+        matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", false), Err(VerifyError::Rollback { .. })),
+        "without a switch a lower version is a rollback"
+    );
+    let m = decision_manifest("stable", "v0.1.0", FRESH, "v0.1.0");
+    assert!(
+        matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", true), Ok(UpdateEvaluation::Available(_))),
+        "an explicit switch adopts the target head regardless of version order"
+    );
+    // A crossgrade to the identical version is still a no-op.
+    let m = decision_manifest("stable", "v0.2.0", FRESH, "v0.1.0");
+    assert!(
+        matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", true), Ok(UpdateEvaluation::UpToDate)),
+        "crossgrade to the same version is up to date"
     );
 }
 
@@ -102,7 +199,7 @@ fn updater_no_download_on_failed_check() {
         (VALID_JSON, VALID_SIG, "v0.1.0"),          // below min_from
     ] {
         let mut downloaded = false;
-        let outcome = check_and_prepare(bytes, sig, current, NOW, |_m| {
+        let outcome = check_and_prepare(bytes, sig, current, NOW, "stable", false, |_m| {
             downloaded = true;
             Ok(())
         });
@@ -112,7 +209,7 @@ fn updater_no_download_on_failed_check() {
 
     // Up to date: no error, no download.
     let mut downloaded = false;
-    let outcome = check_and_prepare(VALID_JSON, VALID_SIG, "v9.9.9", NOW, |_m| {
+    let outcome = check_and_prepare(VALID_JSON, VALID_SIG, "v9.9.9", NOW, "stable", false, |_m| {
         downloaded = true;
         Ok(())
     });
@@ -121,7 +218,7 @@ fn updater_no_download_on_failed_check() {
 
     // Available: download runs, manifest is returned.
     let mut downloaded = false;
-    let outcome = check_and_prepare(VALID_JSON, VALID_SIG, "v0.3.0", NOW, |m| {
+    let outcome = check_and_prepare(VALID_JSON, VALID_SIG, "v0.3.0", NOW, "stable", false, |m| {
         assert_eq!(m.version, "v9.9.9");
         downloaded = true;
         Ok(())

--- a/crates/cp-orchestrator/src/services/releases/updater/verify.rs
+++ b/crates/cp-orchestrator/src/services/releases/updater/verify.rs
@@ -25,6 +25,16 @@ pub enum VerifyError {
     Signature(String),
     /// The (signed) JSON does not parse into the frozen [`Manifest`] schema.
     Parse(String),
+    /// The manifest governs a different channel than the one the box follows —
+    /// a validly-signed manifest served (or replayed) at the wrong URL. This is
+    /// the sole guard on the head-tracking path, which drops the semver
+    /// anti-rollback that would otherwise catch a cross-channel manifest.
+    ChannelMismatch {
+        /// The channel this box configured (the `{channel}.json` it fetched).
+        expected: String,
+        /// The channel the signed manifest actually governs.
+        found: String,
+    },
     /// A timestamp field is malformed.
     Timestamp {
         /// Which manifest field failed to parse.
@@ -58,6 +68,9 @@ impl std::fmt::Display for VerifyError {
         match self {
             Self::Signature(e) => write!(f, "manifest signature verification failed: {e}"),
             Self::Parse(e) => write!(f, "manifest does not match the frozen schema: {e}"),
+            Self::ChannelMismatch { expected, found } => {
+                write!(f, "manifest governs channel {found} but this box follows {expected} — refused")
+            }
             Self::Timestamp { field, value } => write!(f, "manifest {field} is not a valid timestamp: {value}"),
             Self::Expired { expires_at } => write!(f, "manifest expired at {expires_at} (stale replay?)"),
             Self::Rollback { offered, current } => {
@@ -71,7 +84,10 @@ impl std::fmt::Display for VerifyError {
 }
 
 /// Verify a fetched manifest end-to-end and decide what it means for a box
-/// running version `current` at `now_epoch_secs` (UTC seconds).
+/// running version `current` at `now_epoch_secs` (UTC seconds), following
+/// `expected_channel`. `allow_crossgrade` is set for an explicit admin channel
+/// switch, where the box adopts the target channel's head regardless of version
+/// ordering (§ nightly channel decision).
 ///
 /// # Errors
 ///
@@ -82,6 +98,8 @@ pub fn evaluate_manifest(
     signature: &str,
     current: &str,
     now_epoch_secs: u64,
+    expected_channel: &str,
+    allow_crossgrade: bool,
 ) -> Result<UpdateEvaluation, VerifyError> {
     // 1. Signature over the exact bytes, against the embedded trust anchor.
     let key = minisign_verify::PublicKey::from_base64(UPDATE_PUBKEY)
@@ -93,11 +111,59 @@ pub fn evaluate_manifest(
     // 2. Only now is the content worth parsing.
     let manifest: Manifest = serde_json::from_slice(manifest_bytes).map_err(|e| VerifyError::Parse(e.to_string()))?;
 
-    // 3. Freshness (§5.6): refuse a signed-but-stale manifest.
+    // 3. Everything past the signature is a pure decision over the parsed
+    //    manifest — split out so the channel/anti-rollback matrix is unit
+    //    testable without a valid signature (fixtures are signed with the real
+    //    release key, so a new one cannot be minted in tests).
+    evaluate_parsed(manifest, current, now_epoch_secs, expected_channel, allow_crossgrade)
+}
+
+/// Decide what a **verified** (signature already checked) manifest means for a
+/// box on `current` following `expected_channel`. Order: channel match →
+/// freshness → "is-newer".
+///
+/// The "is-newer" rule is channel-dependent:
+/// * **Head-tracking** (`expected_channel == "nightly"`, or `allow_crossgrade`
+///   for an explicit switch): adopt any version that differs from `current`.
+///   `nightly` tags are `v<ver>-<sha>` whose `semver_sort_key` collapses to the
+///   same `(M,m,p)`, so monotonic comparison can never see a newer nightly; and
+///   an explicit switch may legitimately move the version in any direction.
+///   The [`ChannelMismatch`](VerifyError::ChannelMismatch) guard above is the
+///   only thing standing in for the dropped anti-rollback here.
+/// * **Monotonic** (`stable` steady state): the original semver + `min_from`
+///   anti-rollback (§5.6).
+///
+/// # Errors
+///
+/// The first failed check as a [`VerifyError`].
+pub(crate) fn evaluate_parsed(
+    manifest: Manifest,
+    current: &str,
+    now_epoch_secs: u64,
+    expected_channel: &str,
+    allow_crossgrade: bool,
+) -> Result<UpdateEvaluation, VerifyError> {
+    // 1. Channel match — a validly-signed manifest for another channel served
+    //    at this channel's URL is refused (the head-tracking path drops the
+    //    semver guard that would otherwise catch it).
+    if manifest.channel != expected_channel {
+        return Err(VerifyError::ChannelMismatch { expected: expected_channel.to_owned(), found: manifest.channel });
+    }
+
+    // 2. Freshness (§5.6): refuse a signed-but-stale manifest.
     let expires = iso8601_to_epoch(&manifest.expires_at)
         .ok_or_else(|| VerifyError::Timestamp { field: "expires_at", value: manifest.expires_at.clone() })?;
     if expires <= now_epoch_secs {
         return Err(VerifyError::Expired { expires_at: manifest.expires_at });
+    }
+
+    // 3. "Is-newer" — head-tracking for nightly / an explicit switch, else the
+    //    monotonic anti-rollback for stable steady state.
+    if allow_crossgrade || expected_channel == "nightly" {
+        if manifest.version == current {
+            return Ok(UpdateEvaluation::UpToDate);
+        }
+        return Ok(UpdateEvaluation::Available(manifest));
     }
 
     // 4. Anti-rollback (§5.6): monotonic version + min_from floor.

--- a/crates/cp-orchestrator/src/services/releases/updater/verify.rs
+++ b/crates/cp-orchestrator/src/services/releases/updater/verify.rs
@@ -212,3 +212,91 @@ pub(crate) fn iso8601_to_epoch(s: &str) -> Option<u64> {
     let days = u64::try_from(era * 146_097 + doe - 719_468).ok()?;
     Some(days * 86_400 + hour * 3_600 + minute * 60 + second)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fixed "now" (2027-01-15) and a `expires_at` well past it.
+    const NOW: u64 = 1_800_000_000;
+    const FRESH: &str = "2126-01-01T00:00:00Z";
+
+    /// Bare manifest for the pure-decision tests — `evaluate_parsed` ignores
+    /// artifacts, so only channel/version/expires/min_from need to be real. No
+    /// signature is involved, so this exercises the channel matrix without the
+    /// real release key the signed fixtures require.
+    fn manifest(channel: &str, version: &str, expires_at: &str, min_from: &str) -> Manifest {
+        Manifest {
+            schema: 1,
+            channel: channel.to_owned(),
+            version: version.to_owned(),
+            released_at: "2026-07-10T12:00:00Z".to_owned(),
+            expires_at: expires_at.to_owned(),
+            min_from: min_from.to_owned(),
+            notes_url: String::new(),
+            artifacts: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// The channel-aware "is-newer" matrix: nightly head-tracking, the
+    /// channel-equality guard, and forced adoption on an explicit switch.
+    #[test]
+    fn channel_decisions() {
+        // Nightly head-tracking: a different sha at the same (M,m,p) is an update…
+        let m = manifest("nightly", "v0.1.0-def5678", FRESH, "v0.1.0");
+        assert!(
+            matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Ok(UpdateEvaluation::Available(_))),
+            "a new nightly sha at the same semver must be Available"
+        );
+        // …and the identical version is UpToDate (no perpetual re-apply).
+        let m = manifest("nightly", "v0.1.0-abc1234", FRESH, "v0.1.0");
+        assert!(
+            matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Ok(UpdateEvaluation::UpToDate)),
+            "the same nightly build is up to date"
+        );
+
+        // Nightly ignores the min_from floor (head-tracking drops anti-rollback).
+        let m = manifest("nightly", "v0.1.0-def5678", FRESH, "v9.9.9");
+        assert!(
+            matches!(evaluate_parsed(m, "v0.0.1-old", NOW, "nightly", false), Ok(UpdateEvaluation::Available(_))),
+            "nightly skips the min_from floor"
+        );
+
+        // Freshness still bites on nightly: an expired manifest is a stale replay.
+        let m = manifest("nightly", "v0.1.0-def5678", "2020-01-01T00:00:00Z", "v0.1.0");
+        assert!(
+            matches!(evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false), Err(VerifyError::Expired { .. })),
+            "an expired nightly manifest is refused"
+        );
+
+        // Channel-equality guard: a signed *stable* manifest served where nightly
+        // is expected is refused — the only guard left on the head-tracking path.
+        let m = manifest("stable", "v0.2.12", FRESH, "v0.1.0");
+        assert!(
+            matches!(
+                evaluate_parsed(m, "v0.1.0-abc1234", NOW, "nightly", false),
+                Err(VerifyError::ChannelMismatch { .. })
+            ),
+            "a cross-channel manifest must be refused"
+        );
+
+        // Forced adoption on an explicit switch: crossgrade bypasses the semver
+        // anti-rollback that would otherwise reject a lower stable version.
+        let m = manifest("stable", "v0.1.0", FRESH, "v0.1.0");
+        assert!(
+            matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", false), Err(VerifyError::Rollback { .. })),
+            "without a switch a lower version is a rollback"
+        );
+        let m = manifest("stable", "v0.1.0", FRESH, "v0.1.0");
+        assert!(
+            matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", true), Ok(UpdateEvaluation::Available(_))),
+            "an explicit switch adopts the target head regardless of version order"
+        );
+        // A crossgrade to the identical version is still a no-op.
+        let m = manifest("stable", "v0.2.0", FRESH, "v0.1.0");
+        assert!(
+            matches!(evaluate_parsed(m, "v0.2.0", NOW, "stable", true), Ok(UpdateEvaluation::UpToDate)),
+            "crossgrade to the same version is up to date"
+        );
+    }
+}

--- a/crates/cp-orchestrator/src/transport/rest/config/update.rs
+++ b/crates/cp-orchestrator/src/transport/rest/config/update.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 use super::super::{Backend, HttpReply};
 use crate::services::ReleaseStore;
 use crate::services::releases::updater::{
-    UpdateEvaluation, UpdateState, check_stable, download_artifact, restart_self, scheduler, stage_apply,
+    UpdateEvaluation, UpdateState, check_channel, download_artifact, restart_self, scheduler, stage_apply,
 };
 use crate::services::releases::{MaintenanceWindow, UpdateMode};
 
@@ -65,19 +65,28 @@ pub(crate) fn update_status(state: &Mutex<Backend>) -> HttpReply {
 /// refreshed status. A failed check (network, signature…) is a `502` and the
 /// last-known state is kept.
 pub(crate) fn update_check(state: &Mutex<Backend>) -> HttpReply {
-    let (releases_dir, current) = {
+    let (releases_dir, channel, current, crossgrade) = {
         let Ok(b) = state.lock() else {
             return HttpReply::error(500, "backend lock poisoned");
         };
-        (b.releases.dir().to_path_buf(), scheduler::current_version(&b.releases))
+        (
+            b.releases.dir().to_path_buf(),
+            b.releases.channel().to_owned(),
+            scheduler::current_version(&b.releases),
+            b.releases.pending_channel_switch(),
+        )
     };
     // Network I/O with the lock released.
-    let outcome = check_stable(&releases_dir, &current);
-    let Ok(b) = state.lock() else {
+    let outcome = check_channel(&releases_dir, &channel, &current, crossgrade);
+    let Ok(mut b) = state.lock() else {
         return HttpReply::error(500, "backend lock poisoned");
     };
     match outcome {
-        Ok(_evaluation) => HttpReply::ok(&status_json(&b)),
+        // A verified answer on the new channel retires the crossgrade window.
+        Ok(_evaluation) => {
+            b.releases.clear_pending_switch();
+            HttpReply::ok(&status_json(&b))
+        }
         Err(e) => HttpReply::error(502, &format!("check failed: {e}")),
     }
 }
@@ -90,21 +99,35 @@ pub(crate) fn update_apply(state: &Mutex<Backend>) -> HttpReply {
     let Ok(install) = std::env::current_exe() else {
         return HttpReply::error(500, "cannot resolve the running binary path");
     };
-    let (releases_dir, arch, current) = {
+    let (releases_dir, arch, channel, current, crossgrade) = {
         let Ok(b) = state.lock() else {
             return HttpReply::error(500, "backend lock poisoned");
         };
-        (b.releases.dir().to_path_buf(), b.releases.arch().to_owned(), scheduler::current_version(&b.releases))
+        (
+            b.releases.dir().to_path_buf(),
+            b.releases.arch().to_owned(),
+            b.releases.channel().to_owned(),
+            scheduler::current_version(&b.releases),
+            b.releases.pending_channel_switch(),
+        )
     };
 
     // 1. Fresh verified check (network, no lock).
-    let manifest = match check_stable(&releases_dir, &current) {
+    let manifest = match check_channel(&releases_dir, &channel, &current, crossgrade) {
         Err(e) => return HttpReply::error(502, &format!("check failed: {e}")),
         Ok(UpdateEvaluation::UpToDate) => {
+            if let Ok(mut b) = state.lock() {
+                b.releases.clear_pending_switch();
+            }
             return HttpReply::ok(&serde_json::json!({ "status": "up_to_date", "current": current }));
         }
         Ok(UpdateEvaluation::Available(manifest)) => manifest,
     };
+    // The switch resolved to a concrete target; retire the crossgrade window
+    // now so a mid-apply failure doesn't re-trigger head-tracking next poll.
+    if let Ok(mut b) = state.lock() {
+        b.releases.clear_pending_switch();
+    }
 
     // 2. Serialise applies across REST + scheduler.
     if APPLY_IN_FLIGHT.swap(true, Ordering::SeqCst) {
@@ -135,29 +158,52 @@ pub(crate) fn update_apply(state: &Mutex<Backend>) -> HttpReply {
     HttpReply::ok(&serde_json::json!({ "status": "applying", "from": current, "to": manifest.version }))
 }
 
-/// `PUT /api/update/mode` — set the update mode and/or the maintenance
-/// window. Body: `{ "mode": "auto"|"manual"|"paused", "window": { "start":
-/// "HH:MM", "end": "HH:MM" } }` (each field optional, at least one required).
+/// `PUT /api/update/mode` — set the update mode, channel, and/or the
+/// maintenance window. Body: `{ "mode": "auto"|"manual"|"paused", "channel":
+/// "stable"|"nightly", "window": { "start": "HH:MM", "end": "HH:MM" } }` (each
+/// field optional, at least one required).
 pub(crate) fn update_set_mode(state: &Mutex<Backend>, body: &[u8]) -> HttpReply {
+    /// The publishable channels — an unknown value yields a free `400` (like
+    /// `UpdateMode`), so the store never sees an invalid channel string.
+    #[derive(Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    enum Channel {
+        Stable,
+        Nightly,
+    }
+    impl Channel {
+        fn as_str(&self) -> &'static str {
+            match self {
+                Self::Stable => "stable",
+                Self::Nightly => "nightly",
+            }
+        }
+    }
     #[derive(Deserialize)]
     struct Req {
         mode: Option<UpdateMode>,
+        channel: Option<Channel>,
         window: Option<MaintenanceWindow>,
     }
     let Ok(req) = serde_json::from_slice::<Req>(body) else {
         return HttpReply::error(
             400,
-            "expected {\"mode\":\"auto|manual|paused\",\"window\":{\"start\":..,\"end\":..}}",
+            "expected {\"mode\":\"auto|manual|paused\",\"channel\":\"stable|nightly\",\"window\":{\"start\":..,\"end\":..}}",
         );
     };
-    if req.mode.is_none() && req.window.is_none() {
-        return HttpReply::error(400, "nothing to update: provide mode and/or window");
+    if req.mode.is_none() && req.channel.is_none() && req.window.is_none() {
+        return HttpReply::error(400, "nothing to update: provide mode, channel and/or window");
     }
     let Ok(mut b) = state.lock() else {
         return HttpReply::error(500, "backend lock poisoned");
     };
     if let Some(window) = req.window {
         if let Err(e) = b.releases.set_window(window) {
+            return HttpReply::error(400, &e);
+        }
+    }
+    if let Some(channel) = req.channel {
+        if let Err(e) = b.releases.set_channel(channel.as_str()) {
             return HttpReply::error(400, &e);
         }
     }
@@ -203,6 +249,30 @@ mod tests {
         let reloaded = ReleaseStore::load(dir.join("releases"));
         assert_eq!(reloaded.update_mode(), UpdateMode::Manual);
         assert_eq!(reloaded.window().start, "22:00");
+
+        drop(std::fs::remove_dir_all(&dir));
+    }
+
+    /// The channel field on `PUT /api/update/mode` switches the box channel
+    /// (reflected in the next status) and rejects unknown channels with `400`.
+    #[test]
+    fn update_routes_channel_switch() {
+        let (state, dir) = backend("channel");
+
+        assert!(update_status(&state).body.contains("\"channel\":\"stable\""), "default channel");
+
+        let set = update_set_mode(&state, br#"{"channel":"nightly"}"#);
+        assert_eq!(set.status, 200, "{}", set.body);
+        assert!(set.body.contains("\"channel\":\"nightly\""), "channel switched: {}", set.body);
+
+        // Persisted server-side.
+        let reloaded = ReleaseStore::load(dir.join("releases"));
+        assert_eq!(reloaded.channel(), "nightly");
+        assert!(reloaded.pending_channel_switch(), "switch armed the crossgrade flag");
+
+        // An unknown channel is refused and changes nothing.
+        assert_eq!(update_set_mode(&state, br#"{"channel":"beta"}"#).status, 400, "unknown channel refused");
+        assert!(update_status(&state).body.contains("\"channel\":\"nightly\""));
 
         drop(std::fs::remove_dir_all(&dir));
     }

--- a/crates/cp-orchestrator/tests/openapi/paths.rs
+++ b/crates/cp-orchestrator/tests/openapi/paths.rs
@@ -345,11 +345,12 @@ pub(super) fn paths() -> Value {
         "/api/update/check": post("update", "Force a channel poll now", None, r("UpdateStatus")),
         "/api/update/apply": post("update", "Verify, download and apply the channel version now (off-window)", None, r("UpdateApplyResponse")),
         "/api/update/mode": json!({ "put": {
-            "tags": ["update"], "summary": "Set update mode and/or maintenance window",
+            "tags": ["update"], "summary": "Set update mode, channel, and/or maintenance window",
             "requestBody": { "required": true, "content": { "application/json": { "schema": {
                 "type": "object",
                 "properties": {
                     "mode": { "type": "string", "enum": ["auto", "manual", "paused"] },
+                    "channel": { "type": "string", "enum": ["stable", "nightly"] },
                     "window": r("UpdateWindow")
                 }
             }}}},

--- a/openapi.json
+++ b/openapi.json
@@ -5429,6 +5429,13 @@
             "application/json": {
               "schema": {
                 "properties": {
+                  "channel": {
+                    "enum": [
+                      "stable",
+                      "nightly"
+                    ],
+                    "type": "string"
+                  },
                   "mode": {
                     "enum": [
                       "auto",
@@ -5469,7 +5476,7 @@
             "description": "Error"
           }
         },
-        "summary": "Set update mode and/or maintenance window",
+        "summary": "Set update mode, channel, and/or maintenance window",
         "tags": [
           "update"
         ]

--- a/web/src/components/shell/config/UpdatePane.tsx
+++ b/web/src/components/shell/config/UpdatePane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
+  AlertTriangle,
   ArrowUpCircle,
   CheckCircle2,
   ExternalLink,
@@ -79,6 +80,7 @@ export function UpdatePane() {
     <div className="flex flex-col gap-5">
       <VersionCard status={data} onApplying={setApplying} />
       <ModeSection status={data} />
+      <ChannelSection status={data} />
       {/* Keyed on the server value: when the box reports a new window the
           editor remounts and re-seeds its inputs — no state-sync effect. */}
       <WindowSection key={`${data.window.start}-${data.window.end}`} status={data} />
@@ -258,6 +260,71 @@ function ModeSection({ status }: { status: UpdateStatus }) {
       </div>
       {setMode.isError && (
         <span className="text-[11px] text-(--danger)">Could not save: {setMode.error.message}</span>
+      )}
+    </section>
+  )
+}
+
+/**
+ * Nightly opt-in — a single checkbox that flips the box channel
+ * `stable ↔ nightly`. Nightly tracks the tip of `master` (every push), so it
+ * is untested and may be unstable; the warning banner makes that explicit. The
+ * box keeps its existing mode/window, so an `auto` box applies nightly builds
+ * in its maintenance window.
+ */
+function ChannelSection({ status }: { status: UpdateStatus }) {
+  const qc = useQueryClient()
+  const nightly = status.channel === "nightly"
+  const setChannel = useMutation({
+    mutationFn: (channel: "stable" | "nightly") => setUpdateMode({ channel }),
+    onSuccess: (fresh) => qc.setQueryData(["update-status"], fresh),
+  })
+
+  return (
+    <section className="flex flex-col gap-2">
+      <span className="text-[10.5px] font-semibold tracking-[0.07em] text-muted-foreground/80 uppercase">
+        Release channel
+      </span>
+      <label
+        htmlFor="update-nightly"
+        className="card-shadow flex cursor-pointer items-center gap-2.5 rounded-xl border border-border bg-card px-3.5 py-3"
+      >
+        <input
+          id="update-nightly"
+          data-testid="update-channel-nightly"
+          type="checkbox"
+          aria-label="Receive nightly builds"
+          checked={nightly}
+          disabled={setChannel.isPending}
+          onChange={(e) => setChannel.mutate(e.target.checked ? "nightly" : "stable")}
+          className="size-4 shrink-0 accent-(--interactive)"
+        />
+        <span className="flex min-w-0 flex-col">
+          <span className="text-[13px] font-medium text-foreground/90">
+            Receive nightly builds (unstable)
+          </span>
+          <span className="text-[11px] text-muted-foreground">
+            Follow the tip of the development branch instead of stable releases
+          </span>
+        </span>
+      </label>
+      {nightly && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-(--danger)/40 bg-card px-3 py-2.5 text-[11.5px] text-foreground/80"
+        >
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-(--danger)" />
+          <span>
+            Nightly builds ship straight from the latest commit on <code>master</code> with no
+            release testing — they can be unstable or break features. Uncheck to return to stable;
+            your box will move back to the latest stable release on its next check.
+          </span>
+        </div>
+      )}
+      {setChannel.isError && (
+        <span className="text-[11px] text-(--danger)">
+          Could not save: {setChannel.error.message}
+        </span>
       )}
     </section>
   )

--- a/web/src/lib/api/generated/sdk.gen.ts
+++ b/web/src/lib/api/generated/sdk.gen.ts
@@ -626,7 +626,7 @@ export const postApiUpdateApply = <ThrowOnError extends boolean = false>(options
 export const postApiUpdateCheck = <ThrowOnError extends boolean = false>(options?: Options<PostApiUpdateCheckData, ThrowOnError>): RequestResult<PostApiUpdateCheckResponses, PostApiUpdateCheckErrors, ThrowOnError> => (options?.client ?? client).post<PostApiUpdateCheckResponses, PostApiUpdateCheckErrors, ThrowOnError>({ url: '/api/update/check', ...options });
 
 /**
- * Set update mode and/or maintenance window
+ * Set update mode, channel, and/or maintenance window
  */
 export const putApiUpdateMode = <ThrowOnError extends boolean = false>(options: Options<PutApiUpdateModeData, ThrowOnError>): RequestResult<PutApiUpdateModeResponses, PutApiUpdateModeErrors, ThrowOnError> => (options.client ?? client).put<PutApiUpdateModeResponses, PutApiUpdateModeErrors, ThrowOnError>({
     url: '/api/update/mode',

--- a/web/src/lib/api/generated/types.gen.ts
+++ b/web/src/lib/api/generated/types.gen.ts
@@ -2815,6 +2815,7 @@ export type PostApiUpdateCheckResponse = PostApiUpdateCheckResponses[keyof PostA
 
 export type PutApiUpdateModeData = {
     body: {
+        channel?: 'stable' | 'nightly';
         mode?: 'auto' | 'manual' | 'paused';
         window?: UpdateWindow;
     };

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -199,6 +199,7 @@ export function applyUpdate(): Promise<import("./generated/types.gen").UpdateApp
 
 export function setUpdateMode(body: {
   mode?: "auto" | "manual" | "paused"
+  channel?: "stable" | "nightly"
   window?: import("./generated/types.gen").UpdateWindow
 }): Promise<import("./generated/types.gen").UpdateStatus> {
   return sdk(putApiUpdateMode({ body }))


### PR DESCRIPTION
Add a `nightly` release channel that tracks the tip of `master`, alongside the existing `stable` channel, with a checkbox in the Update settings to opt a box in (with an instability warning).

CI (release.yml): the manifest job is parameterized — a `v*` tag publishes `stable.json` (90-day expiry), a push to `master` publishes `nightly.json` (14-day expiry). Both pin all five arches (pcat/musl, the two other Linux lanes, both macOS) so every platform self-selects its own artifact. The push to the `channels` branch is now a fetch–rebase–retry loop so a concurrent tag and master publish can't clobber each other.

Client: fetch/check are channel-aware (`{channel}.json`). `evaluate_manifest` splits into signature-verify + a channel-aware `evaluate_parsed`, which asserts `manifest.channel == expected_channel` (ChannelMismatch — the sole guard on the head-tracking path) and then, for nightly (or an explicit switch), head-tracks by version-string inequality instead of semver — auto-release tags are `v0.1.0-<sha>` whose semver key collapses, so monotonic comparison can never see a newer nightly. Stable steady-state keeps the original monotonic + min_from anti-rollback.

Channel switch = forced adoption: a `pending_channel_switch` config flag armed by `set_channel`, threaded as `allow_crossgrade`, makes the box adopt the target channel's head regardless of version ordering, then clears once a check resolves. `PUT /api/update/mode` gains an optional `channel` field.

Frontend: a nightly checkbox + warning banner in the Update pane; regenerated OpenAPI spec + TS client.


