### PR TITLE
fix(web): refresh model picker after Claude OAuth login

### DIFF
--- a/web/src/components/shell/widgets/UsageButton.tsx
+++ b/web/src/components/shell/widgets/UsageButton.tsx
@@ -11,6 +11,7 @@ import {
   refreshClaudeLogin,
 } from "@/lib/api"
 import { cn } from "@/lib/utils"
+import { resetProviderCache } from "@/lib/support/models"
 import { StoredAccounts } from "./StoredAccounts"
 import { UsageLimits } from "./UsageLimits"
 
@@ -322,12 +323,22 @@ export function UsageButton() {
   const [open, setOpen] = useState(false)
   const queryClient = useQueryClient()
 
+  // A token change can flip the OAuth providers between usable and not, so every
+  // token-affecting success must also refresh the provider registry — drop the
+  // memoised singleton (which never expires on its own) and invalidate the
+  // `["providers"]` query (prefix-matches the picker's `["providers","picker"]`
+  // too) so mounted model pickers refetch instead of showing "No models
+  // available" until a full page reload.
+  const invalidateTokenDependents = () => {
+    void queryClient.invalidateQueries({ queryKey: ["claude-token-status"] })
+    void queryClient.invalidateQueries({ queryKey: ["claude-usage"] })
+    resetProviderCache()
+    void queryClient.invalidateQueries({ queryKey: ["providers"] })
+  }
+
   const refreshMutation = useMutation({
     mutationFn: refreshClaudeLogin,
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["claude-token-status"] })
-      void queryClient.invalidateQueries({ queryKey: ["claude-usage"] })
-    },
+    onSuccess: invalidateTokenDependents,
   })
 
   const tokenStatus = useQuery({
@@ -391,10 +402,7 @@ export function UsageButton() {
     }
   }, [tokenStatus.data])
 
-  const handleLoginDone = () => {
-    void queryClient.invalidateQueries({ queryKey: ["claude-token-status"] })
-    void queryClient.invalidateQueries({ queryKey: ["claude-usage"] })
-  }
+  const handleLoginDone = invalidateTokenDependents
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/web/src/lib/support/models.ts
+++ b/web/src/lib/support/models.ts
@@ -83,12 +83,25 @@ function enrichProviders(raw: GenProviderDef[]): ProviderDef[] {
  *  module-level binding from inside a function. */
 const providerCache: { value: ProviderDef[] | null } = { value: null }
 
+/** Drop the memoised registry so the next `fetchProviders` re-asks the server.
+ *  Call after any event that can change provider *usability* — a Claude OAuth
+ *  login, account switch, or token refresh — then invalidate the `["providers"]`
+ *  query so mounted pickers refetch instead of reading a stale singleton. */
+export function resetProviderCache(): void {
+  providerCache.value = null
+}
+
 /** Fetch the full usable provider registry (cached after first call). The
  *  backend already drops providers without a configured key and stamps each
  *  model with its canonical `key`, so this is the admin-facing catalog (every
  *  usable model, unfiltered by the org allowlist). */
 export async function fetchProviders(): Promise<ProviderDef[]> {
-  if (providerCache.value) return providerCache.value
+  // An empty registry is a valid but *transient* state — it means nothing was
+  // usable when we last asked (e.g. before the Claude OAuth login). Memoising it
+  // would be fatal: `[]` is truthy, so it would pin "No models available"
+  // forever, even after login makes providers appear. Only cache a non-empty
+  // result; otherwise fall through and re-ask the server on the next call.
+  if (providerCache.value?.length) return providerCache.value
   const data = await fetchProviderDefs()
   providerCache.value = enrichProviders(data)
   return providerCache.value


### PR DESCRIPTION
## Problème

Connecté via OAuth Claude, le sélecteur de modèles affiche **« No models available »** — les modèles n'apparaissent qu'après un rechargement complet de la page (Ctrl+Shift+R).

## Cause

`useProviders` → `fetchProviders` mémoïse le registre dans un singleton module-level dont le garde `if (providerCache.value)` traite un **tableau vide comme un cache hit** (`[]` est *truthy* en JS).

Séquence : on ouvre le cockpit **avant** le login OAuth (et sans clé API) → `GET /api/providers` renvoie `[]` (aucun provider utilisable) → `providerCache.value = []`. Après le login OAuth réussi, le backend renverrait bien `claudecodev2` / `claudecode`, mais `fetchProviders` court-circuite sur le `[]` figé (et `staleTime: Infinity` empêche tout refetch). Le picker reste bloqué jusqu'à un reload complet (nouvelle instance de module).

## Correctif

- **`models.ts`** : ne mémoïser qu'un registre **non vide** (`providerCache.value?.length`), pour qu'un `[]` transitoire (avant login) soit ré-interrogé au lieu d'être figé. Nouvel export `resetProviderCache()`.
- **`UsageButton.tsx`** : sur **login** / **switch de compte** / **refresh de token**, appeler `resetProviderCache()` puis `invalidateQueries(["providers"])` (le prefix-match de React Query couvre aussi `["providers","picker"]`), pour que les pickers montés (AgentModal, ConfigPanes) se rafraîchissent sans reload.

## Vérifications

- `tsc --noEmit` ✅
- `eslint` ✅
- `prettier --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)