### PR TITLE
fix(update): OTA promotes the served SPA with the binaries

### DIFF
--- a/crates/cp-orchestrator/src/services/releases/updater/apply.rs
+++ b/crates/cp-orchestrator/src/services/releases/updater/apply.rs
@@ -13,7 +13,10 @@
 //! 3. Healthy boot: the health-gated committer (`boot_commit_when_healthy`)
 //!    clears the binary markers, then [`promote_committed`] flips
 //!    `active_tag`/agent binary to the new tag (both binaries now point at the
-//!    same release — §5.5 step 5), drops the DB backup, records `success`.
+//!    same release — §5.5 step 5), repoints the served-SPA symlink at the tag's
+//!    bundled front (so the UI moves with the binaries), drops the DB backup,
+//!    records `success`. The front is swapped **only here**, post-health, so
+//!    the rollback paths never need to touch it.
 //! 4. Crash-looping boot: `boot_check` restores the `.bak` binary after the
 //!    tolerance; on the old binary's next boot [`boot_reconcile`] sees the
 //!    orphaned `pending-update.json`, **restores `auth.db`** from the backup
@@ -105,7 +108,8 @@ pub fn stage_apply(
 }
 
 /// Promote a committed update: flip `active_tag` + the agent binary to the
-/// staged tag, drop the DB backup, record `success`. Call **only after** the
+/// staged tag, repoint the served-SPA symlink (`CP_WEB_ROOT`) at the tag's
+/// bundled front, drop the DB backup, record `success`. Call **only after** the
 /// health-gated boot commit blessed the new binary.
 ///
 /// Returns the new agent binary path when an update was promoted, `None` when
@@ -125,6 +129,15 @@ pub fn promote_committed(store: &mut ReleaseStore, _auth_db_path: &Path) -> Resu
     // Both binaries move together (§5.5 step 5): the running orchestrator is
     // already the new tag; select() repoints the agent binary + active_tag.
     let agent_binary = store.select(&pending.to)?;
+
+    // Move the served frontend with the binaries so the SPA no longer lags an
+    // OTA (it used to stay on whatever the last Ansible deploy laid down).
+    // Non-fatal: the binaries are the source of truth; a failed symlink swap
+    // just leaves the previous SPA in place until the next successful update.
+    let web_symlink = std::env::var_os("CP_WEB_ROOT").map(PathBuf::from);
+    if let Err(e) = promote_web(store, &pending.to, web_symlink.as_deref()) {
+        eprintln!("updater: web promote failed — front stays on the previous SPA: {e}");
+    }
 
     if let Some(backup) = &pending.db_backup {
         let _rm = std::fs::remove_file(backup);
@@ -207,6 +220,81 @@ pub fn restart_self(install: &Path) {
         eprintln!("updater: exec of {} failed: {err}; exiting for supervisor respawn", install.display());
         std::process::exit(1);
     });
+}
+
+/// Atomically repoint the served-SPA symlink (`CP_WEB_ROOT`, i.e.
+/// `{cp_root}/web/current`) at this tag's bundled front (`releases/<tag>/web`),
+/// so the frontend moves with the binaries instead of lagging on whatever the
+/// last Ansible deploy laid down.
+///
+/// `web_symlink` is the `CP_WEB_ROOT` path (the caller passes
+/// `env::var_os("CP_WEB_ROOT")`). No-op when:
+/// * `web_symlink` is `None` — an API-only deployment with the SPA fronted by a
+///   separate web server (the orchestrator's historical mode);
+/// * the release ships no `web/` payload — an older or binary-only bundle: the
+///   served SPA is left exactly as it was rather than pointed at nothing.
+///
+/// Called from [`promote_committed`], i.e. **after** the new binary answered
+/// `/healthz` `200`. Because the swap only happens post-health, the rollback
+/// paths never touch the front — a failed update leaves `current` pointing at
+/// the previous SPA, so there is nothing to restore.
+///
+/// # Errors
+///
+/// Returns an error if the symlink swap itself fails; the caller treats this as
+/// non-fatal.
+pub(crate) fn promote_web(store: &ReleaseStore, tag: &str, web_symlink: Option<&Path>) -> Result<(), String> {
+    let Some(link) = web_symlink else {
+        return Ok(()); // API-only deployment — no SPA to promote
+    };
+    let target = store.dir().join(tag).join("web");
+    if !target.is_dir() || dir_is_empty(&target) {
+        return Ok(()); // binary-only bundle — keep serving the current SPA
+    }
+    swap_web_symlink(link, &target)
+}
+
+/// True when `dir` has no entries (or cannot be read).
+fn dir_is_empty(dir: &Path) -> bool {
+    std::fs::read_dir(dir).map(|mut e| e.next().is_none()).unwrap_or(true)
+}
+
+/// Point `link` at `target`: write a sibling temp symlink and `rename` it over
+/// `link`. Renaming onto an existing symlink is atomic — there is no instant
+/// where the served root is absent. A pre-existing **real directory** at `link`
+/// (a legacy deploy that copied the SPA in place instead of symlinking) is
+/// removed first so the rename can land.
+///
+/// # Errors
+///
+/// Returns an error if any filesystem step fails; `link` is left pointing where
+/// it did unless the final rename succeeds.
+#[cfg(unix)]
+fn swap_web_symlink(link: &Path, target: &Path) -> Result<(), String> {
+    use std::os::unix::fs::symlink;
+    let parent = link.parent().ok_or_else(|| format!("web symlink {} has no parent", link.display()))?;
+    std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+
+    // Legacy layout guard: a real directory at `link` (old in-place deploy)
+    // must go before the rename — `rename(symlink, dir)` fails. A symlink is
+    // replaced by the rename itself, atomically.
+    let is_real_dir = link.symlink_metadata().map(|m| m.file_type().is_dir()).unwrap_or(false);
+    if is_real_dir {
+        std::fs::remove_dir_all(link).map_err(|e| format!("remove legacy web dir {}: {e}", link.display()))?;
+    }
+
+    let tmp = parent.join(".current.tmp");
+    let _rm = std::fs::remove_file(&tmp);
+    symlink(target, &tmp).map_err(|e| format!("symlink {} -> {}: {e}", tmp.display(), target.display()))?;
+    std::fs::rename(&tmp, link).map_err(|e| {
+        let _cleanup = std::fs::remove_file(&tmp);
+        format!("promote web symlink {} -> {}: {e}", link.display(), target.display())
+    })
+}
+
+#[cfg(not(unix))]
+fn swap_web_symlink(_link: &Path, _target: &Path) -> Result<(), String> {
+    Ok(()) // the appliance is Unix-only
 }
 
 /// Sibling backup path: `auth.db.bak-<oldtag>` (`§5.5` step 2).

--- a/crates/cp-orchestrator/src/services/releases/updater/tests.rs
+++ b/crates/cp-orchestrator/src/services/releases/updater/tests.rs
@@ -5,7 +5,7 @@
 //! §5.4.1), so these tests exercise the exact embedded trust anchor.
 
 use super::super::{ReleaseStore, boot_check, boot_commit_when_healthy, semver_sort_key};
-use super::apply::{boot_reconcile, promote_committed, stage_apply};
+use super::apply::{boot_reconcile, promote_committed, promote_web, stage_apply};
 use super::download::{tag_dir, verify_and_extract};
 use super::state::{UpdateResult, UpdateState};
 use super::verify::iso8601_to_epoch;
@@ -321,6 +321,43 @@ fn updater_apply_rollback_cycle() {
         matches!(st.last_result, Some(UpdateResult::RolledBack { ref attempted, .. }) if attempted == "vY"),
         "rollback recorded: {st:?}"
     );
+
+    drop(std::fs::remove_dir_all(&base));
+}
+
+// ── OTA front — the served-SPA symlink moves with the binaries ──────────────
+
+/// The front follows the binaries: on promote, `promote_web` atomically
+/// repoints the `web/current` symlink (`CP_WEB_ROOT`) at the release's bundled
+/// `releases/<tag>/web`, and is a no-op when the bundle ships no `web/` (compat)
+/// or `CP_WEB_ROOT` is unset (API-only deployment).
+#[cfg(unix)]
+#[test]
+fn promote_web_moves_the_served_spa() {
+    use std::os::unix::fs::symlink;
+    let base = temp_dir("webprom");
+    // Ansible day-0: web/baseline holds the shipped SPA, web/current -> baseline.
+    let current = base.join("web/current");
+    std::fs::create_dir_all(base.join("web/baseline")).expect("baseline dir");
+    std::fs::write(base.join("web/baseline/index.html"), b"OLD").expect("old spa");
+    symlink("baseline", &current).expect("current symlink");
+    let store = ReleaseStore::load(base.join("releases"));
+    let served = || std::fs::read(current.join("index.html")).expect("read served");
+    // No-op guards leave current -> baseline: a tag with no bundled web/, and
+    // an unset CP_WEB_ROOT, both keep serving the day-0 SPA.
+    promote_web(&store, "vY", Some(current.as_path())).expect("no-op: no bundled web");
+    promote_web(&store, "vY", None).expect("no-op: CP_WEB_ROOT unset");
+    assert_eq!(served(), b"OLD", "front untouched by the no-op guards");
+    assert_eq!(std::fs::read_link(&current).expect("target"), std::path::Path::new("baseline"));
+
+    // A release that bundles web/ is promoted: current atomically repoints at
+    // releases/vY/web and stays a symlink.
+    std::fs::create_dir_all(store.dir().join("vY/web")).expect("tag web dir");
+    std::fs::write(store.dir().join("vY/web/index.html"), b"NEW").expect("new spa");
+    promote_web(&store, "vY", Some(current.as_path())).expect("promote web");
+    assert_eq!(served(), b"NEW", "release SPA after promote");
+    assert!(current.symlink_metadata().expect("meta").file_type().is_symlink(), "stays a symlink");
+    assert_eq!(std::fs::read_link(&current).expect("target"), store.dir().join("vY/web"));
 
     drop(std::fs::remove_dir_all(&base));
 }

--- a/deploy/ansible/tasks/deploy.yml
+++ b/deploy/ansible/tasks/deploy.yml
@@ -45,12 +45,24 @@
     - { src: "{{ artifacts_dir }}/bundle/cpilot", dst: tui }
     - { src: "{{ artifacts_dir }}/caddy", dst: caddy }
 
-- name: Ship the SPA bundle (from the release bundle)
+- name: Ship the SPA bundle into web/baseline (from the release bundle)
+  # The served root is the `web/current` symlink (CP_WEB_ROOT); day-0 it points
+  # at this baseline. The OTA updater atomically repoints `current` at the
+  # active release's own `releases/<tag>/web`, so the front moves with the
+  # binaries. A redeploy re-lays baseline AND resets current -> baseline below,
+  # matching the freshly-shipped SPA to the freshly-shipped binaries.
   ansible.builtin.copy:
     src: "{{ artifacts_dir }}/bundle/web/"
-    dest: "{{ cp_root }}/web/"
+    dest: "{{ cp_root }}/web/baseline/"
     mode: "0644"
     directory_mode: "0755"
+
+- name: Point web/current at the baseline SPA (OTA repoints it thereafter)
+  ansible.builtin.file:
+    src: baseline
+    dest: "{{ cp_root }}/web/current"
+    state: link
+    force: true
 
 - name: Install the systemd units (templated with cp_root)
   ansible.builtin.template:

--- a/deploy/ansible/templates/context-pilot.service.j2
+++ b/deploy/ansible/templates/context-pilot.service.j2
@@ -23,7 +23,10 @@ Environment=CP_ORCH_PORT=7878
 Environment=CP_CADDYFILE={{ cp_root }}/caddy/Caddyfile
 Environment=CP_CADDY_BIN={{ cp_root }}/bin/caddy
 Environment=CP_CA_ROOT={{ cp_root }}/caddy/data/caddy/pki/authorities/local/root.crt
-Environment=CP_WEB_ROOT={{ cp_root }}/web
+# Served SPA — a `current` symlink the OTA updater atomically repoints at the
+# active release's bundled front (`releases/<tag>/web`). Day-0 it points at
+# `web/baseline` (the SPA Ansible shipped); a failed update never touches it.
+Environment=CP_WEB_ROOT={{ cp_root }}/web/current
 Environment=CP_AGENT_BINARY={{ cp_root }}/bin/tui
 # Provisioning values (templated by Ansible, chmod 600). Loaded as KEY=value.
 #   seed.env      — per-UNIT admin seed (CP_SEED_ADMIN_*); write-once, seeded

--- a/docs/update-policy.md
+++ b/docs/update-policy.md
@@ -16,9 +16,11 @@
 > Armbian/Debian 13 + **systemd**, and the apply model moved from
 > client-initiated to **automatic**:
 >
-> 1. **App-only auto-update.** Only `cp-console-server` + `cpilot` self-update.
->    OS, Caddy, Tailscale, the systemd unit and the updater itself are day-0 /
->    Ansible / break-glass (§5.7).
+> 1. **App-only auto-update.** Only the orchestrator + `cpilot` self-update,
+>    and the **served SPA moves with them** — on promote the updater repoints
+>    the `CP_WEB_ROOT` `web/current` symlink at the new tag's bundled
+>    `releases/<tag>/web` (fix/ota-front). OS, Caddy, Tailscale, the systemd unit
+>    and the updater itself are day-0 / Ansible / break-glass (§5.7).
 > 2. **Promotion = auto on tag `v*`.** Pushing a tag publishes the signed
 >    `stable` manifest in CI; tagging *is* the fleet release act.
 > 3. **Box default = `auto`, nightly window 03:00–05:00 box-local** —
@@ -341,10 +343,15 @@ binary embedding the new public key. This is the §5.7 escape hatch, not OTA.
 
 ### §5.7 — Out of scope (state it explicitly)
 
-The manifest governs **only** the app binaries (`cp-console-server` + `cpilot`). The
-wrapper, Caddy, Tailscale, the procd init script, and the OpenWrt OS (`sysupgrade`)
-are handled via day-0 / Ansible / break-glass. Rings/canary are **out of v1** (fleet
-too small to matter). Keeping these out prevents scope creep.
+The manifest governs the app binaries (the orchestrator + `cpilot`) **and the
+served SPA that ships alongside them** in the same tarball: on promote the
+updater atomically repoints the `CP_WEB_ROOT` `web/current` symlink at
+`releases/<tag>/web`, so the UI never lags the API across an OTA (fix/ota-front).
+The swap happens only after the new binary is health-blessed, so a rolled-back
+update leaves the front pointing at the previous SPA — no front rollback path is
+needed. Caddy, Tailscale, the systemd unit, and the host OS are still handled via
+day-0 / Ansible / break-glass. Rings/canary are **out of v1** (fleet too small to
+matter). Keeping these out prevents scope creep.
 
 ### §5.8 — The subtle trap: DB schema migrations
 


### PR DESCRIPTION
## Problème

L'OTA ne swappait que les binaires (orchestrateur + `cpilot`). Le frontend restait figé sur le dernier SPA déployé par Ansible : une release avec des changements API+UI couplés laissait l'UI périmée jusqu'à un redéploiement.

## Fix

Le front bascule désormais avec les binaires. Au promote, l'updater repointe **atomiquement** le symlink `CP_WEB_ROOT` (`web/current`) vers le `releases/<tag>/web` bundlé de la nouvelle release.

- Le swap n'a lieu qu'**après** que le nouveau binaire a passé `/healthz` → les chemins de rollback n'ont rien à défaire côté front (un update rollbacké laisse `current` sur l'ancien SPA).
- **No-op** si `CP_WEB_ROOT` absent (déploiement API-only) ou si le bundle ne livre pas de `web/` (compat vieux bundles).
- Garde-fou legacy : un vrai dossier à la place du symlink est retiré avant le rename.

## Déploiement

- `CP_WEB_ROOT` devient `{{cp_root}}/web/current`.
- Ansible pose le SPA dans `web/baseline/` et crée `web/current -> baseline` au day-0 (tag-free ; l'OTA repointe ensuite).
- ⚠️ Les box déjà déployées nécessitent un redéploiement pour établir le layout `web/current` (changement de valeur du unit systemd).

## Tests

3 nouveaux tests unitaires (repointe vers `releases/<tag>/web` ; no-op sans `web/` ; no-op sans `CP_WEB_ROOT`). Les cycles apply healthy/rollback existants passent toujours (37/37 dans le module `releases`).

CI inchangée : le tarball embarque déjà `web/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)