### PR TITLE
Server-side Claude OAuth auto-refresh + memory tl_dr cap raise

### DIFF
--- a/.context-pilot/shared/tree-descriptions.yaml
+++ b/.context-pilot/shared/tree-descriptions.yaml
@@ -4970,6 +4970,10 @@
   path: crates/cp-mod-prompt/src/skill_panel.rs
   description: Skill panel UI. Markdown-rendered content via cp_render::markdown::to_blocks(). Title/refresh/context methods. refresh() syncs cached_content for all loaded skills.
   last_edited_ms: 0
+3c9e87852c6bd69c:
+  path: crates/cp-mod-console/src/lib.rs
+  description: 'Console module. 5 tools. Dynamic console panels. init: find/create Unix socket server. save/load: session reconnection + orphan cleanup. Leaks stdin on save to prevent EOF. Tool visualizer. console_wait max_wait param default 60.'
+  last_edited_ms: 1785266957561
 3c9f7e6eefbd3fa7:
   path: web/src/components/shell/config/UpdatePane.tsx
   description: Desktop Update pane (O5.2). Version+channel, auto/manual/paused mode, maintenance window, apply-progress poll. All server-persisted /api/update/*. Mobile twin exists.
@@ -9850,6 +9854,10 @@
   path: src/ui/ir/render_sidebar.rs
   description: 'Sidebar ratatui renderer. A6: bar-fill fractions routed via float_math (mul/div/add). Token bar box, pagination, PR card, stats. content_width const-fn #[expect(as_conversions)].'
   last_edited_ms: 1784534060386
+7784a22d68b86e23:
+  path: crates/cp-mod-console/src/tools.rs
+  description: 'Console tools: create, send_keys, wait, watch, easy_bash. CONSOLE_WAIT_BLOCKING_SENTINEL const. Git/gh guardrails. console_wait max_wait default+cap = 60s (was 30).'
+  last_edited_ms: 1785266957468
 77938a5be7952a78:
   path: crates/cp-render/src/lib.rs
   description: 'IR crate root. Semantic + Block (#[non_exhaustive]) + Align enum #[expect(exhaustive_enums)] A4. Span with semantic+modifiers.'
@@ -10814,6 +10822,10 @@
   path: web/src/components/shell/SessionVitals.tsx
   description: Session vitals as an EMBEDDABLE section (no Dialog chrome) — extracted from the deleted StatsPopup (T321). Context-budget meter + figure chips (Context/Panels/Session cost) + on-demand Service-vitals connectivity board (fetchVitals, prepends the 2 browser-only rows). Rendered inside AgentModal manage mode's right column.
   last_edited_ms: 1782119305882
+82493d7ccbee31a7:
+  path: crates/cp-mod-console/src/types.rs
+  description: 'Console types. ProcessStatus enum #[non_exhaustive]. SessionMeta, ConsoleState, ConsoleWatcher (exit/pattern, easy_bash inline vs panel overflow). check_timeout now preserves_tempo on BOTH branches (console_wait + easy_bash timeouts no longer break tempo).'
+  last_edited_ms: 1785266957359
 8251aca4fb98413d:
   path: ui/src/components/threads/ThreadConversation.tsx
   description: 'Center pane: selected thread''s full conversation. toChatMessage() maps ThreadMsg→ChatMessage to reuse cockpit Message renderer. Renders embedded QuestionForm + fileRef chips. ThreadComposer at bottom.'

--- a/.context-pilot/shared/tree-descriptions.yaml
+++ b/.context-pilot/shared/tree-descriptions.yaml
@@ -2042,6 +2042,10 @@
   path: docs/threads.md
   description: 'Design doc for threads feature: parallel discussion/work topics. Core model, tools (Send/Read/Ask), coucou integration (recurrent scheduling), fixed panel, Ctrl+V threads view. Status: brainstorm.'
   last_edited_ms: 1781349633701
+18db81cfaaf56157:
+  path: deploy/PROVISIONING.md
+  description: 'Full Context Pilot box provisioning procedure (FR). Factory box → prod cockpit. Two access planes (vendor→tailnet, client→LAN). Port allocation (:443 cockpit, :9090 maint, :8088 LuCI, :22 SSH). Phases 0–4: Tailscale control-plane + control node, day-0 (AP WiFi + static Tailscale binary + procd service + enroll), build artifact, Ansible deploy, IT onboarding. Phase 3bis: optional Claude Code OAuth subscription creds (read-only, no refresh). Decisions + operational caveats (self-cut on Tailscale upgrade, key-expiry, firewall, /mnt/data).'
+  last_edited_ms: 0
 18e69c0c8055006e:
   path: web/src/components/agents/AgentModal.tsx
   description: 'Agent create/manage dialog. useProviders() hook fetches registry. Manage: 2-col (960px) — left = name + ModelPicker (providers prop), right = SessionVitals + ACL. Submit sends Configure + rename. Create: single-col, persists defaults to localStorage.'
@@ -2745,6 +2749,10 @@
 21a717360bc91e22:
   path: web/src/lib/api/generated/client/index.ts
   description: 'Client barrel re-exports: createClient, createConfig, mergeHeaders, type exports (Client, Config, Options, RequestResult, TDataShape, etc).'
+  last_edited_ms: 0
+21a95a92203a432c:
+  path: web/src/components/threads/ThreadConversation.tsx
+  description: 'Center pane: thread conversation + composer. T510 FREEZE FIX: MessageRow React.memo (comparator msg===+agentId===) + AutoRun memo + useMemo(segmentLog) + content-visibility:auto per row. useConversationDrop hook (T367/T471 OS-file drag+zip). scrollIntoView measure-wrapped, 6-frame converge. FileSidebar rail for thread attachments.'
   last_edited_ms: 0
 21b5a0d10a4cb88f:
   path: web/src/components/threads/ThreadsView.tsx
@@ -4602,6 +4610,10 @@
   path: web/src/components/finder/preview/FinderPreview.tsx
   description: 'Quick Look preview shell + Body() kind router. Routes node → mock previews (mockPreviews), live fetchers (livePreviews), or shared leaf renderers (previewParts). T306: the drawer header''s Download button is wired to downloadFile(agentId, node.path) (streams the realm file via the backend attachment endpoint) — actionable only in the live Finder (agentId scopes the realm), inert in the mock; hidden for folders. The decorative Share button was removed app-wide (no utility).'
   last_edited_ms: 1782054164059
+387e923db29ebc7f:
+  path: .context-pilot/shared/tree-descriptions.yaml
+  description: Persisted tree descriptions YAML. Synced to git alongside code commits per M15.
+  last_edited_ms: 0
 387f3b11754928d1:
   path: crates/cp-mod-entities/src/lib.rs
   description: Entities module trait impl. init_state with recovery priority (DB→dump→migrations→fresh). save_module_data with dump regeneration + WAL checkpoint. entity_sql tool dispatch. overview_context_section. Depends on search.
@@ -7350,6 +7362,10 @@
   path: crates/cp-base/src/state/context.rs
   description: 'Kind registry + Entry type. TypeMeta 9-field #[expect(exhaustive_structs)] A5 (25 cross-crate sites). A6: estimate_tokens via float_math::ceil_ratio. EmittedState/ScrollState/Entry #[non_exhaustive]+builders. make_default_entry.'
   last_edited_ms: 0
+588d7e7323bf6994:
+  path: crates/cp-orchestrator/src/runtime/mod.rs
+  description: 'Orchestrator runtime — Config (env vars: port, maint_port, agents_dir, scan_interval, auth, session_ttl) + Runtime (start_driver background thread + serve HTTP). driver_loop: registry scan (slow cadence) + oplog tail (fast 100ms TAIL_INTERVAL) + config mtime backstop + auth backup. Two listeners: product :7878 + maintenance :9090. Caddy apply at boot.'
+  last_edited_ms: 0
 58d63e6da1bfd473:
   path: ui/src/components/shell/StatsPopup.tsx
   description: Session 'vitals' popup — the stats that used to live in the cockpit's right rail, now summoned from an Activity button in the global TopBar header. Portaled Dialog primitive (escapes vibrancy containing block). Context-budget meter + threshold tick + stat rows from mock.stats.
@@ -7741,6 +7757,10 @@
 5edaca03764ba233:
   path: crates/cp-mod-queue/src/lib.rs
   description: 'Queue module. 3 tools: pause/execute/undo. Fixed QUEUE panel. Not core. QueueState: active, queued_calls, next_index. Trap state (trap_active/panel_ids/optional_ids) persisted in save/load. Queue_execute handled in pipeline.rs (needs dispatch). Reverie-allowed.'
+  last_edited_ms: 0
+5edb9bb5a1a91bbc:
+  path: README.md
+  description: 'Project README — global ARCHITECTURE overview (rewritten from the old philosophy/marketing copy, T278). 10 sections + ASCII topology diagram: system overview (5 surfaces), the agent TUI (main loop/modules/panels/LLM providers/tier-② persistence), three-tier durability + push-vs-inspection planes, the orchestrator (registry/services/supervisor/transport routes), the bridge (CP_BRIDGE=1 boot sequence), the web frontend (TanStack Query + SSE push), sidecars (console server, Meilisearch, SQLite entities), the cp-wire protocol types, repo layout, engineering constraints (500-line/8-entry caps, lints, hash chain) + flame telemetry.'
   last_edited_ms: 0
 5ef0edc62bb421db:
   path: crates/cp-orchestrator/Cargo.toml
@@ -9282,6 +9302,10 @@
   path: web/src/components/agents/AgentModal/actions.ts
   description: 'AgentModal mutations hook (P8 split): useAgentModalActions bundles create/rename/restart/retire/avatar mutations + Esc/⌘↵ key handler (bound once via latest-refs). Uses useRestartFlow for full restart lifecycle (API call + SSE drop detection + reconnect wait + 30s failsafe). ActionsArgs object bundles 7 params (max-params 4). saveManage sends configure+rename; create maps apiName.'
   last_edited_ms: 1784202781489
+71c22c2e75d783c3:
+  path: web/src/mobile-components/auth/DayZeroSetup.tsx
+  description: Mobile day-0 provisioning twin. 2-phase wizard (identity/trust), 16px Field inputs, py-3 buttons. Same POST /api/it/identity + CA fingerprint poll logic.
+  last_edited_ms: 0
 71c66f2db2c64dbf:
   path: crates/cp-orchestrator/src/services/auth/store.rs
   description: AuthStore — SQLite-backed auth CRUD. Schema init (users/sessions/agent_acl), Argon2id hashing, token/UUID generation. User CRUD, session lifecycle (create/validate/revoke with lazy sweep). ACL ops extracted to sibling acl.rs.
@@ -9386,6 +9410,10 @@
   path: crates/cp-orchestrator/src/transport/inspect/finder/sheet.rs
   description: 'Finder spreadsheet→table JSON (T282): fs_sheet (GET /fs/sheet?path=). csv/tsv via the `csv` reader (quote+embedded-newline aware); xlsx/xls/xlsb/ods/xlsm via calamine open_workbook_auto. Both collapse to {sheets:[{name,rows:[[cell]]}],truncated}, every cell stringified (cell_to_string: integral floats lose the .0 tail). Bounded MAX_ROWS=1000 × MAX_COLS=50 × MAX_SHEETS=20; csv read-capped 8MiB. Confined via support:: (escape 403, non-file 404, unsupported/unparseable 415, missing param 400).'
   last_edited_ms: 1781896321103
+730186e6941125c9:
+  path: deploy/photonicat/emmc-install/installer/init-sd-install.sh
+  description: The zero-touch flasher on the init-SD. Guard stamp, optional factory-OpenWrt backup, zstd -dc golden.img.zst | dd of=/dev/mmcblk0, background LCD progress (polls dd /proc fdinfo pos), sha256 readback verify, poweroff (=done signal, safe to pull SD). Error leaves board on with ERROR screen.
+  last_edited_ms: 0
 730bf605abb836a5:
   path: crates/cp-mod-console/src/types.rs
   description: 'Console types. ProcessStatus enum #[expect(exhaustive_enums)] A4. SessionMeta, ConsoleState, ConsoleWatcher (exit/pattern, easy_bash inline vs panel overflow).'
@@ -9650,6 +9678,10 @@
   path: web/src/components/Root.tsx
   description: Desktop tree root — extracted from former App.tsx body. Provider-contract boundary + AppShell (view-router fleet/threads/finder/costs, TopBar+StatusBar, live vitals/SSE, disconnect overlay). Mirror twin of mobile Root.
   last_edited_ms: 1784666644246
+7588f9ad4a60ec72:
+  path: web/src/components/threads/ThreadComposer.tsx
+  description: 'Thread composer — always active, regardless of turn status. Turn-status banner reflects agent activity on this thread (T39/T371). Structure (P8): draft logic in useComposer, banner in ComposerBanner, input row in ComposerInputRow. T556: prefix-filtered /command bubbles with Tab autocomplete and Space expansion.'
+  last_edited_ms: 0
 758c6087049c485e:
   path: crates/cp-mod-search/src/panel.rs
   description: Search result panel + YAML formatter. format_results groups chunks by path + logs + entities. update_if_changed via let _changed (T586).
@@ -10566,6 +10598,10 @@
   path: openapi.json
   description: Generated OpenAPI 3.0.3 spec (70KB). Source of truth for TypeScript client codegen. Regenerated from Rust types via tests/openapi.rs.
   last_edited_ms: 0
+80400004d69ff42d:
+  path: crates/cp-orchestrator/tests/openapi/schemas_ext.rs
+  description: Transport-layer OpenAPI schemas — receipts, auth, env-keys, filesystem, FinderKind, LLM registry, SSE delta protocol (OpEntryKind incl 'state' field for lifecycle deltas — T566), release management, Claude Code usage+login.
+  last_edited_ms: 0
 80619247f5c1d0f5:
   path: web/src/components/shell/widgets/UserMenu.tsx
   description: 'Account avatar menu (T30). Gradient AvatarMark trigger + portaled dropdown: identity header div, Profile/Settings/Manage Users (Phase 10, admin-only)/Sign-out. Sign out wired to useAuth().logout when auth enabled. onOpenUsers callback triggers admin UsersDialog.'
@@ -10857,6 +10893,10 @@
 838aab6a32750248:
   path: crates/cp-orchestrator/tests/supervisor_lifecycle.rs
   description: 'Phase 28 (X795) backend supervisor lifecycle suite (4 tests, all green, ~15s). Black-box public-API + real OS processes, covering what supervisor/tests.rs unit tests can''t: (1) SIGTERM→grace→SIGKILL escalation vs `/bin/sh -c "trap '''' TERM; exec sleep 60"` (unit spawn_and_stop never walks escalation path); (2) multi-agent fleet spawn 3 → stop all → all pids ESRCH-gone (spawned children reaped, no zombie); (3) adopted FOREIGN process really signalled on stop (status.signal()==SIGTERM 15; supervisor signals but doesn''t reap what it didn''t spawn); (4) check_liveness routes spawned Exited (try_wait) + adopted Vanished (signal-0) in ONE pass. pid_present helper via nix kill(_,None)!=ESRCH. Top `use cp_mod_bridge/cp_oplog/serde/serde_json/tiny_http as _;`.'
+  last_edited_ms: 0
+83a1f2ecfe457def:
+  path: web/src/components/auth/DayZeroSetup.tsx
+  description: 'Day-0 provisioning screen (next_action=set_identity): name the box (DNS/IP) then distribute CA root; posts POST /api/it/identity, brings :443 up.'
   last_edited_ms: 0
 83c59efd682f0ecc:
   path: tedx.md
@@ -12178,6 +12218,10 @@
   path: crates/cp-mod-callback/src/trigger.rs
   description: Callback trigger engine. collect_changed_files() extracts paths from Edit/Write tools. match_callbacks() with flame!("cb_match") matches files against glob patterns. validate_skip_names() warns on non-existent callbacks. partition_callbacks() splits blocking/async.
   last_edited_ms: 0
+936371f437344897:
+  path: deploy/photonicat/emmc-install/lcd/pcat_lcd.py
+  description: GC9307 SPI LCD 4-state progress painter (flashing PCT/verify/done/error). Python spidev+libgpiod, 5x7 bitmap font, init sequence transcribed from vendor periph.io-gc9307 st7789.go. /dev/spidev1.0, RST=122 DC=121, 172x320 rot180 MADCTL 0x48 coloffset 34. One-shot per state screen.
+  last_edited_ms: 0
 93675230eb37ea5b:
   path: .git/index
   description: Git index (binary). Not source.
@@ -12333,6 +12377,10 @@
 9557ff70b0d90a25:
   path: src/modules/conversation/render_input_blocks.rs
   description: IR input area renderer. Cursor + paste placeholder expansion + command highlighting + selection highlighting (via apply_selection_to_spans with reversed spans). InputBlockCtx context, expand_paste_sentinels mapping, command hints.
+  last_edited_ms: 0
+955927c3631059fd:
+  path: web/README.md
+  description: 'Web client documentation: architecture (REST+SSE two-plane), quick start (run-stack.sh), manual start, env vars, data flow (inspection+orchestration planes), key directories, tech stack.'
   last_edited_ms: 0
 9567f58da9cf921d:
   path: src/infra/mod.rs
@@ -13050,6 +13098,10 @@
   path: crates/cp-wire/src/types/command.rs
   description: Command envelope (id, seq, dedup_token) + Kind (SendMessage, CreateThread, ArchiveThread, RestoreThread, PauseThread, ResumeThread, DeleteThread, InterruptStream, Stop, Configure{provider,model}, Unknown). Frame{schema_version, auth, command}. PauseThread/ResumeThread added for T371. DeleteThread added for T371 permanent delete.
   last_edited_ms: 1782315774512
+9e6f9c6ed64b39a7:
+  path: deploy/photonicat/emmc-install/build/build-init-sd.sh
+  description: 'Assembles the init-SD: write base Debian image to card, grow rootfs, seed installer payload (init-sd-install.sh + pcat_lcd.py + unit + golden.img.zst), strip the firstboot unit (target-only). Inputs via env: BASE_IMG/CARD/GOLDEN_DIR. Interactive card-device confirm.'
+  last_edited_ms: 0
 9e742fd75d006bc4:
   path: src/ui/threads_view/mod.rs
   description: Threads view layout + thread list rendering. Two-pane layout (thread list | messages). Virtual '+ New Thread' entry. IR pipeline for list items (status dots, unread indicators, selection highlight). maybe_activate_thread_question() lazy question form init. truncate_str helper.
@@ -13430,6 +13482,10 @@ a1be7723d6430d79:
   path: crates/cp-wire/src/types/oplog.rs
   description: 'OpEntry + OpEntryKind internally-tagged enum: CommandEffect, SeenMark, PhaseTransition, MessageCreated{...,inline_body}, ThreadCreated/Archived/Restored/Paused/Resumed/Deleted/StatusChanged, ThreadFocusChanged, Lifecycle, CostAggregate, ContextUsage{used,threshold,budget,hit_tokens,miss_tokens (T297 cache split, #[serde(default)] N-1)}, Checkpoint, Unknown. Framed (len+CRC). round-trip + tolerant-decode + roster + stable-tag tests.'
   last_edited_ms: 1782315774544
+a1e294df4d2bd95d:
+  path: web/src/components/threads/ThreadsView.tsx
+  description: 'Desktop ThreadsView — master-detail (list rail + conversation). railOpen collapse (T669) animates (T670): rail stays mounted, slides via transitioned negative left-margin; slide wrapper is flex (T670 fix 7117931e — a plain block wrapper broke the aside''s flex-stretch, collapsing it to content height); root overflow-hidden clips the off-screen rail; floating PanelLeft reopen button fades+nudges in when collapsed; motion-reduce snaps. Shared useThreadSelection+useThreadActions from lib/live/threadView. Mobile twin = stack nav.'
+  last_edited_ms: 0
 a1ffaeff3ac46448:
   path: web/src/components/threads/ThreadsView.tsx
   description: 'Thread sidebar orchestrator. P8 refactor: logic split into TWO same-file hooks — useThreadSelection (selectedId/query/showArchived/newOpen/pendingFiles + effectiveSelectedId resolution + persist effect + auto-select-new-thread diff effect + switch-thread pending-files render-phase reset) and useThreadActions (flash/notice + handleArchive/Pause/Delete/Create/Send/Attach, all routing rejections through describeCommandError toast per T121) — so the render body meets the 150-line/30-statement budgets. `thread` lookup moved below the no-agent early exit (unicorn/no-declarations-before-early-exit). handleAttach uploads to .uploads/ via uploadUnique. Wires ThreadList+ThreadConversation+NewThreadDialog + EmptyRealm.'
@@ -16286,6 +16342,10 @@ c4e9d7be47211a1c:
   path: crates/cp-mod-queue/Cargo.toml
   description: 'Queue module deps: cp-base, cp-render, crossterm, serde, serde_json.'
   last_edited_ms: 1780563847626
+c50579caadeebb35:
+  path: deploy/photonicat/emmc-install/README.md
+  description: 'Full protocol doc: why (drop armbian-install), verified board facts, file layout, 4-stage flow (golden build, init-SD build, field install, ansible provisioning), 9 pre-solved frictions, open items. Locked decisions + secrets policy.'
+  last_edited_ms: 0
 c509a5f5c91dc5b3:
   path: ui/src/App.tsx
   description: App shell. ViewMode = fleet|threads|cockpit|finder (default fleet). FleetDashboard at fleet altitude; threads/cockpit/finder per-agent. Cockpit = LeftRail + Conversation (RightInspector removed; stats now in header popup). openAgent switches agent→threads. Finder keyed by agent.id.
@@ -17926,6 +17986,10 @@ da174be66a37f518:
   path: src/app/run/reverie.rs
   description: 'Reverie event processing. A9: HashMap iter filter closures over &(&K,&V) -> |entry| entry.0/.1. apply_reverie_event/dispatch_one_reverie_tool/record_reverie_tool_exchange/reverie_over_tool_cap/restream_reverie_if_alive/destroy_reverie_on_report. Multi-agent concurrent.'
   last_edited_ms: 0
+da18e73cedc6db46:
+  path: deploy/photonicat/emmc-install/installer/pcat-installer.service
+  description: systemd oneshot driving init-sd-install.sh. Offline (After=local-fs.target, no network). TimeoutStartSec=1800 (full flash+verify). ConditionPathExists=!/opt/pcat-install/.installed.
+  last_edited_ms: 0
 da1e497617676b58:
   path: crates/cp-base/src/state/data/model_helpers.rs
   description: 'ModelPricing trait: model selection, pricing, context budget, cleaning thresholds — impl for State + token_cost()'
@@ -18430,6 +18494,10 @@ e19314fbc0e8ca8e:
   path: ui/src/components/agents/FleetDashboard.tsx
   description: 'Fleet welcome dashboard — agent create/manage entry. Centred on shared FLEET_MAX_W. Slim header (T28): just an ''Agents'' h1 + New-agent button (no ''Mission control'' label, no subtitle). AgentCard grid (status badge + one-line task + model·cost; Open→threads, Manage→AgentModal), New-agent card. autoCreate prop (T21) opens AgentModal in create mode then calls onAutoCreateConsumed. AgentModal lives in ./AgentModal (T26), shared with the TopBar per-agent config button.'
   last_edited_ms: 1781597617596
+e1a5db4621871daf:
+  path: openapi.json
+  description: Generated OpenAPI 3.0.3 spec (70KB). Source of truth for TypeScript client codegen. Regenerated from Rust types via tests/openapi.rs.
+  last_edited_ms: 0
 e1a8486381ab592f:
   path: .uploads/apply_clippy_fix.py
   description: Applies clippy suggested_replacement by byte offset (highest-first), reads BOTH primary AND child(help) spans. Bypasses cargo --fix MaybeIncorrect skip. EXCLUDE redundant_pub_crate (damaging).
@@ -20338,6 +20406,10 @@ f89ccd9dd26859f5:
   path: web/src/components/finder/FinderChrome.tsx
   description: 'Finder chrome: tab strip, main toolbar (nav/crumbs/view-switch/search/icon-size/actions), path bar + NavBtn/SegBtn. FinderSidebar re-exported from support/.'
   last_edited_ms: 1783412977550
+f8ac4584250fcad4:
+  path: web/src/components/threads/ThreadList.tsx
+  description: Thread sidebar list. Grouped by turn-status (Agent's turn / User turn) + Archived view. Search now lives in ThreadSearchPalette (T669) opened from ListHeader's Search button; ListHeader also has a PanelLeftClose sidebar-collapse button. Row-hover title marquee via useTitleMarquee (WAA). Subcomponents RowActions/RowMeta/ListHeader/EmptyState keep budgets. Exactly 500 lines (cap).
+  last_edited_ms: 0
 f8cfbcdcc4351bbd:
   path: crates/cp-orchestrator/src/transport/mod.rs
   description: Frontend transport REST+SSE over tiny_http. MAX_BODY=32MiB. route_rest dispatches all /api routes incl auth/ACL/env-keys/providers/releases/claude-usage+login+refresh(T451). handle() has centralized Bearer gate + per-agent ACL check. handle_stream = SSE with ticket-based ACL.
@@ -20930,6 +21002,10 @@ ff5e2aa0b27af18c:
   path: crates/cp-base/src/config/accessors/library.rs
   description: Seed prompt library accessors (agents/skills/commands) (A7 split).
   last_edited_ms: 1784536096734
+ff60afa5b9659465:
+  path: .git/index
+  description: Git index (binary). Not source.
+  last_edited_ms: 0
 ff64487da9d7be43:
   path: deploy/ansible/tasks/seed.yml
   description: 'Admin-seed tasks (Obj 6.1/6.2). Idempotent: unit with existing seed.env left untouched. Generates unique 20-char passwords for superadmin (vendor) + admin (client) accounts, writes seed.env chmod 600, writes printable delivery sheet on control node.'

--- a/.context-pilot/shared/tree-descriptions.yaml
+++ b/.context-pilot/shared/tree-descriptions.yaml
@@ -94,6 +94,10 @@
   path: web/src/mobile-components/shell/widgets/UsageButton.tsx
   description: '@generated mobile-mirror stub — re-exports desktop UsageButton (LoginFlow reused by mobile via this token).'
   last_edited_ms: 0
+016998dae3456238:
+  path: crates/cp-orchestrator/src/main.rs
+  description: Backend entry point. Loads .env via dotenvy (project-local + global fallback) before config. Reads Config from env, prints version/protocol/agents-dir/budget/scan-interval + agents_root + agent_binary, creates Runtime, starts driver thread, serves HTTP (blocking).
+  last_edited_ms: 0
 017021fe83997a4c:
   path: src/ui/search_overlay/display.rs
   description: Display column builders for search index overlay. build_left_display + build_right_display split into per-section push_* helpers (database/index/extensions/splitter/embeddings/tasks/recomputed/recently_sent) (A2).
@@ -589,6 +593,10 @@
 06c1b9ac8c794dad:
   path: .git/index
   description: Git index (binary). Not source.
+  last_edited_ms: 0
+06c26e4344158f0b:
+  path: crates/cp-mod-memory/src/tools.rs
+  description: Memory tools. execute_create split create_one_memory(Result<String,String> per-item parse+store). execute_update split UpdateTally struct + delete_memory + apply_memory_fields + modify_memory + apply_one_update + build_update_output (A2). tl_dr 80-token cap validate_tldr.
   last_edited_ms: 0
 06c821b4ca10c31a:
   path: web/src/components/finder/views/ColumnsView.tsx
@@ -2310,6 +2318,10 @@
   path: web/src/components/shell/CockpitView.tsx
   description: 'Cockpit (panel-centered) view assembler. Accepts agentId, passes to LeftRail + PanelPane. Two columns: LeftRail (context navigator) | PanelPane (selected surface). Default selected = ''conversation''.'
   last_edited_ms: 1781695333798
+1c5cd80aa94bc361:
+  path: .context-pilot/shared/tree-descriptions.yaml
+  description: Persisted tree descriptions YAML. Synced to git alongside code commits per M15.
+  last_edited_ms: 0
 1c60356763e64307:
   path: crates/cp-mod-github/Cargo.toml
   description: 'GitHub module deps: cp-base, cp-render, crossterm, regex, sha2, serde_json, secrecy.'
@@ -3522,6 +3534,10 @@
   path: crates/cp-orchestrator/src/services/materialized_view.rs
   description: 'Phase 18: MaterializedView — in-mem fleet projection folded from OpEntry stream (one AgentView per agent). AgentView{rev,heads,phase,lifecycle,cost:CostSnapshot}.apply(&OpEntry): Checkpoint=authoritative heads reset (I5 count-bounded restart mechanism at view layer), MessageCreated=set_thread_head, PhaseTransition/Lifecycle/CostAggregate=latest-wins (cost cumulative-since-boot so NOT summed), CommandEffect/SeenMark/Unknown=inert. rev=max. MaterializedView{agents:HashMap}: apply/apply_batch/get/remove/len/agent_ids. AgentView+CostSnapshot derive Serialize for the REST transport. 7 tests.'
   last_edited_ms: 1781647826946
+2ac66180a810a899:
+  path: crates/cp-orchestrator/src/transport/rest/claude_oauth/sweep.rs
+  description: Background OAuth refresh sweep — standalone thread (BOOT_DELAY 10s, SWEEP_INTERVAL 600s) keeps active-slot token AND every stored account fresh, refreshing any within REFRESH_THRESHOLD_MS (1h) of expiry. No Backend lock (OAuth state on disk/Keychain). Supersedes frontend popover auto-refresh. sweep_once = refresh_active_if_stale + accounts::refresh_stored_accounts.
+  last_edited_ms: 1785266142281
 2acd97845cc5d377:
   path: ui/src/components/panels/cockpit/ToolsPanel.tsx
   description: 'Cockpit Tools maquette: enabled tool registry grouped by category (name, one-line desc, enabled/disabled dot). Reads mock toolGroups.'
@@ -8046,6 +8062,10 @@
   path: src/llms/cache/cache_engine.rs
   description: Cache breakpoint engine. Hash chain (acc_hash = sha256(block + prev)). Tracks alive BPs via hash match. Places beacon at frontier+20. Runs DP optimizer for 3 additional BPs (4 total). 5-min TTL matching Anthropic.
   last_edited_ms: 0
+624686134d31a389:
+  path: crates/cp-orchestrator/src/transport/rest/claude_oauth/mod.rs
+  description: 'Claude Code OAuth helpers: usage proxy, token status, PKCE login flow (start/complete), refresh, credential I/O (Keychain+file). Constants: CLIENT_ID, TOKEN_URL, TOKEN_USER_AGENT, SCOPES. PkceSession stored in Backend. extract_code parses raw/URL/code#state input.'
+  last_edited_ms: 0
 624fe986019b9241:
   path: src/ui/search_overlay/text.rs
   description: Plain-text export of Ctrl+I overlay for clipboard. build_overlay_text split per-section writers write_server/write_index_stats/write_extensions_splitter/write_embeddings/write_task_trailers (A2). Includes Meili CPU%/RAM.
@@ -8498,6 +8518,10 @@
   path: .github/checks/check-file-lengths.sh
   description: File length check script (max 500 lines)
   last_edited_ms: 0
+67d4367356d1236c:
+  path: crates/cp-orchestrator/src/transport/rest/claude_oauth/accounts.rs
+  description: 'Multi-account Claude OAuth token vault. 4 endpoints: list/store/switch/delete. Storage ~/.context-pilot/claude-accounts.json (BTreeMap by email). REFRESH_THRESHOLD_MS=1h. Shared refresh POST extracted to try_refresh (de-dupes 3 call sites); is_stale(threshold), refresh_stored_accounts(threshold) for the sweep; maybe_refresh(threshold) refreshes on switch.'
+  last_edited_ms: 1785266142510
 67f09cfa05b1c9f8:
   path: web/src/components/shell/widgets/UsageButton.tsx
   description: 'Claude Code OAuth usage limits button. Anthropic "A" logomark trigger opens popover with token status (valid/expired + expiry), session/weekly usage bars (color-coded by severity), and LoginFlow (PKCE: open browser → auto-detect via polling → fallback manual code paste). Lazy-fetches on open, 30s auto-refresh.'
@@ -9505,6 +9529,10 @@
 73dd279b530a7953:
   path: web/src/components/threads/forms/FormFields.tsx
   description: '8 form field input renderers: single+allow-other, multi, text, number, date, toggle, confirm+confirm-word, files (immediate upload). FieldInput dispatcher.'
+  last_edited_ms: 0
+7401467bc3e9f87d:
+  path: crates/cp-mod-memory/src/lib.rs
+  description: 'Memory module. 2 tools: memory_create/update. Fixed MEMORY panel. Global, not core. 80-token tl_dr cap. Module data: memories + next_id + open_ids. Importance-gradient visualizer (critical→low).'
   last_edited_ms: 0
 74150afab89d24d0:
   path: src/app/reverie/mod.rs
@@ -11646,6 +11674,10 @@
   path: docs/design-conversation-search.md
   description: T671 conversation-search design doc. Hybrid keyword+semantic search over thread messages, Option B round-trip (frontend->orchestrator->agent->meili). Covers cp_{hash}_conversations index+voyage-code-3 embedder, content_hash reconciler (re-embed changed only, purge vanished, archived stays), Inbound untagged multiplex (command byte-identical), Query/Response/ConvHit wire types, read path, dual-mode palette. File map at end.
   last_edited_ms: 1785160644491
+8c4510cb4a2607af:
+  path: web/src/lib/live/useClaudeUsage.ts
+  description: Claude Code usage/token orchestration (shared desktop+mobile). useClaudeUsage (token-status + usage queries, manual refresh, cache invalidator). useClaudeAccounts (store/switch/delete). useClaudeLogin (PKCE state machine + auto-detect poller). Popover auto-refresh REMOVED — orchestrator sweep owns it server-side now.
+  last_edited_ms: 1785266142418
 8c4aaf61fc72e9ac:
   path: crates/cp-orchestrator/src/transport/rest/releases.rs
   description: 'Release management REST handlers (T427). 5 endpoints: list_releases (GET, merged local+remote+arch+active), set_arch (PUT, manual or auto-detect), download_release (POST, download+extract tarball), select_release (PUT, set active binary+supervisor), delete_release (DELETE). All pub(crate).'
@@ -14634,6 +14666,10 @@ b0ef0be513a36e65:
   path: crates/cp-orchestrator/src/runtime.rs
   description: 'Runtime — env Config (port/agents_dir/budget/scan_interval) + driver loop with TWO decoupled cadences: slow scan_interval (2s) for registry scan + config.json mtime backstop (inspection-resource freshness signal → SSE invalidate; X863 comment precise) + tmp reap; fast TAIL_INTERVAL (100ms) for tail_all_agents (Tailer.poll → view.apply_batch → breaker.observe). serve() blocks on HTTP. Felt-latency path is oplog-tail-primary via the SSE producer''s OplogWaiter (inotify).'
   last_edited_ms: 1781821687524
+b0f60ac39037c1d8:
+  path: crates/cp-orchestrator/src/runtime/mod.rs
+  description: Orchestrator runtime — Config (env vars) + Runtime. start_driver (registry scan + oplog tail). start_oauth_sweeper (Claude token auto-refresh thread). start_update_scheduler + start_update_committer (auto-update). serve (HTTP, Caddy apply at boot).
+  last_edited_ms: 1785266142601
 b115eff75bfa20be:
   path: web/src/mobile-components/threads/forms/FormMessageRow.tsx
   description: Mobile FormMessageRow twin — un-memoized form-bearing row. Routes mobile conversation/Message + FormWidget token. Parse helpers shared (./helpers stub).
@@ -20298,6 +20334,10 @@ f7207867229d3d86:
   path: crates/cp-mod-prompt/Cargo.toml
   description: 'Prompt module crate deps: cp-base, cp-render, crossterm, serde, serde_json, serde_yaml.'
   last_edited_ms: 0
+f74b76107e495ddc:
+  path: crates/cp-orchestrator/src/transport/rest/mod.rs
+  description: 'REST resource handlers. fleet() filtered by ACL. command() dispatches. rename/avatar/threads/body. vault_snapshot + env_keys + settings exports. claude_usage()/token_status()/login_start()/login_complete()/refresh_login() for Claude OAuth (T451). resolve_entry. Submodules: backend, claude_oauth, config, create, lifecycle, releases, thread_shape.'
+  last_edited_ms: 0
 f74fa3be25ccf5fa:
   path: src/modules/conversation_history/mod.rs
   description: 'Conversation history module. Core/global. Dynamic panels for frozen history chunks. on_close_context redirects to Close_conversation_history tool. Sub-modules: panel, trap.'
@@ -20773,6 +20813,10 @@ fc7d4dce281874be:
 fc951562b9dce358:
   path: crates/cp-mod-threads/src/tools.rs
   description: 'Thread tool handlers. execute_send/execute_read/build_panel_content. T353: execute_send AUTO-UNARCHIVES an archived target thread (thread.archived=true → set false) — sending to an archived thread is allowed (AI may remember its id), and the reply makes it visible again, mirroring the web frontend''s unarchive-on-send; surfaced in the tool result as ''[thread was archived — automatically unarchived]''. Archived threads filtered out of LLM-facing context. X887: build_panel_content also filters .filter(|m| !m.auto) (visible Vec, skip/total on non-auto count) so the AI never re-reads its own auto tool-activity traces. T343: tool result only lists threads with unack > 0 (concise). MAX caps on content/file-path/questions/panel-messages.'
+  last_edited_ms: 0
+fc9717f4835fdddb:
+  path: .git/index
+  description: Git index (binary). Not source.
   last_edited_ms: 0
 fc9cc30874f14d93:
   path: ui/src/components/shell/TopBar.tsx

--- a/crates/cp-mod-console/src/lib.rs
+++ b/crates/cp-mod-console/src/lib.rs
@@ -251,7 +251,7 @@ impl Module for ConsoleModule {
                 .param("id", ParamType::String, true)
                 .param_enum("mode", &["exit", "pattern"], true)
                 .param("pattern", ParamType::String, false)
-                .param_with_default("max_wait", ParamType::Integer, "30")
+                .param_with_default("max_wait", ParamType::Integer, "60")
                 .build(),
             ToolDefinition::from_yaml("console_watch", t)
                 .short_desc("Async watch for process event")

--- a/crates/cp-mod-console/src/tools.rs
+++ b/crates/cp-mod-console/src/tools.rs
@@ -256,7 +256,7 @@ pub fn execute_wait(tool: &ToolUse, state: &mut State) -> ToolResult {
         Ok(r) => r,
         Err(e) => return *e,
     };
-    let max_wait: u64 = tool.input.get("max_wait").and_then(serde_json::Value::as_u64).unwrap_or(30).clamp(1, 30);
+    let max_wait: u64 = tool.input.get("max_wait").and_then(serde_json::Value::as_u64).unwrap_or(60).clamp(1, 60);
 
     match early_watch_result(tool, state, &req) {
         Ok(Some(done)) => return done,

--- a/crates/cp-mod-console/src/types.rs
+++ b/crates/cp-mod-console/src/types.rs
@@ -272,6 +272,7 @@ impl Watcher for ConsoleWatcher {
             Some(
                 WatcherResult::new(format!("TIMED OUT after {elapsed_s}s, process may still be running"))
                     .tool_use_id_opt(self.tool_use_id.clone())
+                    .preserves_tempo()
                     .create_panel(
                         DeferredPanel::new(
                             self.session_name.clone(),
@@ -289,7 +290,8 @@ impl Watcher for ConsoleWatcher {
                     self.session_name, elapsed_s, self.panel_id
                 ))
                 .panel_id(self.panel_id.clone())
-                .tool_use_id_opt(self.tool_use_id.clone()),
+                .tool_use_id_opt(self.tool_use_id.clone())
+                .preserves_tempo(),
             )
         }
     }

--- a/crates/cp-mod-memory/src/lib.rs
+++ b/crates/cp-mod-memory/src/lib.rs
@@ -17,8 +17,21 @@ use types::MemoryState;
 
 use cp_base::cast::Safe as _;
 
-/// Maximum token length for memory `tl_dr` field (enforced on create/update)
-pub const MEMORY_TLDR_MAX_TOKENS: usize = 80;
+/// Token budget ADVERTISED to the model for a memory `tl_dr`.
+///
+/// The number quoted in the tool docs and the rejection message. Deliberately
+/// lower than the real limit ([`MEMORY_TLDR_HARD_CAP`]): the model routinely
+/// overshoots a stated cap by a bit, so quoting 80 lands it comfortably under
+/// the true 120 and the create/update succeeds instead of failing on a
+/// marginal overrun.
+pub const MEMORY_TLDR_ADVERTISED_TOKENS: usize = 80;
+
+/// The REAL enforced ceiling for a memory `tl_dr` (create/update reject above).
+///
+/// Never surface this number to the model — it must only ever see
+/// [`MEMORY_TLDR_ADVERTISED_TOKENS`] (80), so its self-trimming aims well below
+/// the true limit and marginal overruns still pass.
+pub const MEMORY_TLDR_HARD_CAP: usize = 120;
 
 use serde_json::json;
 

--- a/crates/cp-mod-memory/src/tools.rs
+++ b/crates/cp-mod-memory/src/tools.rs
@@ -1,4 +1,4 @@
-use super::MEMORY_TLDR_MAX_TOKENS;
+use super::{MEMORY_TLDR_ADVERTISED_TOKENS, MEMORY_TLDR_HARD_CAP};
 use cp_base::state::context::{Kind, estimate_tokens};
 use cp_base::state::runtime::State;
 use cp_base::tools::{ToolResult, ToolUse};
@@ -8,11 +8,17 @@ use crate::types::{MemoryImportance, MemoryItem, MemoryState};
 use std::fmt::Write as _;
 
 /// Validate that a tl;dr summary does not exceed the token limit.
+///
+/// Enforcement uses the real [`MEMORY_TLDR_HARD_CAP`] (120), but the rejection
+/// message quotes only the advertised [`MEMORY_TLDR_ADVERTISED_TOKENS`] (80).
+/// The gap is intentional: the model trims toward the number it's told, so
+/// telling it 80 keeps its output safely under the true 120 and a marginal
+/// overrun (say ~110) still succeeds instead of erroring. Never leak 120 here.
 fn validate_tldr(text: &str) -> Result<(), String> {
     let tokens = estimate_tokens(text);
-    if tokens > MEMORY_TLDR_MAX_TOKENS {
+    if tokens > MEMORY_TLDR_HARD_CAP {
         Err(format!(
-            "tl_dr too long: ~{tokens} tokens (max {MEMORY_TLDR_MAX_TOKENS}). Keep it to a short one-liner; put details in 'contents' instead."
+            "tl_dr too long: ~{tokens} tokens (max {MEMORY_TLDR_ADVERTISED_TOKENS}). Keep it to a short one-liner; put details in 'contents' instead."
         ))
     } else {
         Ok(())

--- a/crates/cp-orchestrator/src/main.rs
+++ b/crates/cp-orchestrator/src/main.rs
@@ -100,6 +100,10 @@ fn main() {
     let runtime = Runtime::new(config);
     let _driver = runtime.start_driver();
 
+    // Keep every Claude OAuth account (active + stored) auto-refreshed, so a
+    // token never expires from under the fleet regardless of any open UI.
+    let _oauth_sweeper = runtime.start_oauth_sweeper();
+
     // Health-gated commit of a staged update (update-policy §5.5): a committer
     // thread polls our own `/healthz` and, only after a real `200` within the
     // deadline, commits the binary swap and promotes the release state

--- a/crates/cp-orchestrator/src/runtime/mod.rs
+++ b/crates/cp-orchestrator/src/runtime/mod.rs
@@ -244,6 +244,15 @@ impl Runtime {
         update_scheduler::spawn(Arc::clone(&self.backend), self.config.auth_db_path.clone(), install)
     }
 
+    /// Spawn the Claude OAuth refresh sweeper: a standalone thread that keeps the
+    /// active token AND every stored account fresh, refreshing any that fall
+    /// within an hour of expiry. Needs no backend state (OAuth lives on disk /
+    /// Keychain), so it takes nothing and holds no locks. See
+    /// [`crate::transport::rest::spawn_oauth_refresh`].
+    pub fn start_oauth_sweeper(&self) -> thread::JoinHandle<()> {
+        crate::transport::rest::spawn_oauth_refresh()
+    }
+
     /// Spawn the self-update committer thread (update-policy §5.5 steps 4-5).
     ///
     /// It polls our own `/healthz` and, once a staged update's boot proves

--- a/crates/cp-orchestrator/src/transport/rest/claude_oauth/accounts.rs
+++ b/crates/cp-orchestrator/src/transport/rest/claude_oauth/accounts.rs
@@ -13,6 +13,10 @@ use super::super::HttpReply;
 
 const ACCOUNTS_FILE: &str = "claude-accounts.json";
 
+/// Refresh a token once it drops within this window of expiry (1 hour). Shared
+/// by the account-switch path and the background sweep so both use one policy.
+pub(super) const REFRESH_THRESHOLD_MS: i64 = 3_600_000;
+
 // ── Stored file format ───────────────────────────────────────────────
 
 /// On-disk shape of `~/.context-pilot/claude-accounts.json`.
@@ -122,8 +126,9 @@ pub(crate) fn switch_account(body_bytes: &[u8]) -> HttpReply {
         return HttpReply::error(404, &format!("no stored account for {email}"));
     };
 
-    // If the access token expired, attempt a refresh before activating.
-    let target_creds = maybe_refresh(target_creds);
+    // If the access token is expired or within an hour of expiry, refresh it
+    // before activating so the switched-to account is comfortably usable.
+    let target_creds = maybe_refresh(target_creds, REFRESH_THRESHOLD_MS);
 
     // Save current active into the store (best-effort: if no active token
     // exists we still proceed with the switch).
@@ -164,22 +169,25 @@ pub(crate) fn delete_account(email: &str) -> HttpReply {
 
 // ── Token refresh ────────────────────────────────────────────────────
 
-/// If the stored token is expired but has a refresh token, attempt a
-/// refresh and return updated credentials. Falls back to the original
-/// on any failure.
-fn maybe_refresh(mut creds: serde_json::Value) -> serde_json::Value {
+/// True when `creds` will expire within `threshold_ms` (or already has) AND
+/// carries a non-empty refresh token to renew with. `threshold_ms == 0` is the
+/// classic "expired only" test; a positive value (e.g. 1h) refreshes early.
+pub(super) fn is_stale(creds: &serde_json::Value, threshold_ms: i64) -> bool {
     let expires_at = creds.get("expiresAt").and_then(|v| v.as_i64()).unwrap_or(0);
-    if expires_at > now_ms() {
-        return creds; // still valid
-    }
-    let refresh_token = creds.get("refreshToken").and_then(|v| v.as_str()).unwrap_or("").to_owned();
-    if refresh_token.is_empty() {
-        return creds; // nothing to refresh with
-    }
+    let has_refresh = creds.get("refreshToken").and_then(|v| v.as_str()).is_some_and(|s| !s.is_empty());
+    has_refresh && expires_at.saturating_sub(now_ms()) < threshold_ms
+}
 
+/// Exchange a refresh token for a fresh `claudeAiOauth` credential blob.
+///
+/// The single shared refresh-grant POST (previously copy-pasted across the
+/// switch and login paths). Returns the new `{accessToken, refreshToken,
+/// expiresAt}` fields folded onto `base`, or `None` on any failure (network,
+/// non-2xx, empty access token) so callers keep the old credentials intact.
+pub(super) fn try_refresh(base: &serde_json::Value, refresh_token: &str) -> Option<serde_json::Value> {
     let body = serde_json::json!({
         "grant_type": "refresh_token",
-        "refresh_token": &refresh_token,
+        "refresh_token": refresh_token,
         "client_id": super::CLIENT_ID,
     });
     let client = reqwest::blocking::Client::new();
@@ -189,23 +197,55 @@ fn maybe_refresh(mut creds: serde_json::Value) -> serde_json::Value {
         .header("User-Agent", super::TOKEN_USER_AGENT)
         .body(body.to_string())
         .timeout(std::time::Duration::from_secs(15))
-        .send();
-
-    let Ok(r) = resp else { return creds };
-    if !r.status().is_success() {
-        return creds;
+        .send()
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
     }
-    let Ok(val) = r.json::<serde_json::Value>() else { return creds };
+    let val = resp.json::<serde_json::Value>().ok()?;
 
     let access_token = val.get("access_token").and_then(|v| v.as_str()).unwrap_or("");
-    let new_refresh = val.get("refresh_token").and_then(|v| v.as_str()).unwrap_or(&refresh_token);
-    let expires_in = val.get("expires_in").and_then(|v| v.as_i64()).unwrap_or(0);
-    let new_expires_at = now_ms() + expires_in * 1000;
-
-    if !access_token.is_empty() {
-        creds["accessToken"] = serde_json::Value::String(access_token.to_owned());
-        creds["refreshToken"] = serde_json::Value::String(new_refresh.to_owned());
-        creds["expiresAt"] = serde_json::json!(new_expires_at);
+    if access_token.is_empty() {
+        return None;
     }
-    creds
+    let new_refresh = val.get("refresh_token").and_then(|v| v.as_str()).unwrap_or(refresh_token);
+    let expires_in = val.get("expires_in").and_then(|v| v.as_i64()).unwrap_or(0);
+
+    let mut creds = base.clone();
+    creds["accessToken"] = serde_json::Value::String(access_token.to_owned());
+    creds["refreshToken"] = serde_json::Value::String(new_refresh.to_owned());
+    creds["expiresAt"] = serde_json::json!(now_ms() + expires_in * 1000);
+    Some(creds)
+}
+
+/// If `creds` is stale (within `threshold_ms` of expiry), attempt a refresh and
+/// return the updated blob. Falls back to the original on any failure.
+fn maybe_refresh(creds: serde_json::Value, threshold_ms: i64) -> serde_json::Value {
+    if !is_stale(&creds, threshold_ms) {
+        return creds;
+    }
+    let refresh_token = creds.get("refreshToken").and_then(|v| v.as_str()).unwrap_or("").to_owned();
+    try_refresh(&creds, &refresh_token).unwrap_or(creds)
+}
+
+/// Refresh every STORED account whose token is within `threshold_ms` of expiry,
+/// rewriting `claude-accounts.json` only when at least one changed. Best-effort:
+/// an individual refresh failure leaves that account's credentials untouched.
+/// The active-slot token is refreshed separately (see `sweep`).
+pub(super) fn refresh_stored_accounts(threshold_ms: i64) {
+    let mut store = read_accounts();
+    let mut dirty = false;
+    for creds in store.accounts.values_mut() {
+        if !is_stale(creds, threshold_ms) {
+            continue;
+        }
+        let refresh_token = creds.get("refreshToken").and_then(|v| v.as_str()).unwrap_or("").to_owned();
+        if let Some(fresh) = try_refresh(creds, &refresh_token) {
+            *creds = fresh;
+            dirty = true;
+        }
+    }
+    if dirty {
+        let _w = write_accounts(&store);
+    }
 }

--- a/crates/cp-orchestrator/src/transport/rest/claude_oauth/mod.rs
+++ b/crates/cp-orchestrator/src/transport/rest/claude_oauth/mod.rs
@@ -6,6 +6,7 @@
 //! browser, then pastes the resulting code back into the frontend dialog.
 
 pub(crate) mod accounts;
+pub(crate) mod sweep;
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};

--- a/crates/cp-orchestrator/src/transport/rest/claude_oauth/sweep.rs
+++ b/crates/cp-orchestrator/src/transport/rest/claude_oauth/sweep.rs
@@ -1,0 +1,58 @@
+//! Background OAuth refresh sweep — keeps EVERY Claude account (the active slot
+//! plus every stored account) within a fresh token, without any UI being open.
+//!
+//! A single standalone thread wakes every [`SWEEP_INTERVAL`], and for each
+//! account whose token is within [`accounts::REFRESH_THRESHOLD_MS`] (1 hour) of
+//! expiry, exchanges its refresh token for a new one. It needs nothing from
+//! [`Backend`](crate::transport::Backend) — all OAuth state lives on disk / in
+//! the Keychain — so it takes no locks and is spawned directly (see
+//! [`crate::runtime`]).
+//!
+//! This supersedes the frontend's popover-scoped auto-refresh: the server keeps
+//! tokens alive continuously, so no user action (or open tab) is required.
+
+use std::thread;
+use std::time::Duration;
+
+use super::accounts::{self, REFRESH_THRESHOLD_MS};
+
+/// How often the sweep runs. A token entering its final hour is therefore
+/// renewed within at most one interval — well before it can expire.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(600);
+
+/// Settle delay before the first sweep — lets the transport bind and the boot
+/// sequence land so a refresh never races startup.
+const BOOT_DELAY: Duration = Duration::from_secs(10);
+
+/// Spawn the OAuth refresh sweeper. One thread for the process lifetime.
+pub(crate) fn spawn() -> thread::JoinHandle<()> {
+    thread::spawn(|| {
+        thread::sleep(BOOT_DELAY);
+        loop {
+            sweep_once();
+            thread::sleep(SWEEP_INTERVAL);
+        }
+    })
+}
+
+/// One pass: refresh the active-slot token if stale, then every stored account.
+fn sweep_once() {
+    refresh_active_if_stale();
+    accounts::refresh_stored_accounts(REFRESH_THRESHOLD_MS);
+}
+
+/// Refresh the ACTIVE (Keychain / `~/.claude/.credentials.json`) token when it
+/// is within an hour of expiry, writing the renewed blob back. Best-effort — a
+/// failed refresh leaves the current credentials in place (the access token may
+/// still have runway; the switch/login flow re-authenticates once it expires).
+fn refresh_active_if_stale() {
+    let Some(creds) = super::read_credentials_json() else { return };
+    if !accounts::is_stale(&creds, REFRESH_THRESHOLD_MS) {
+        return;
+    }
+    let refresh_token = creds.get("refreshToken").and_then(|v| v.as_str()).unwrap_or("").to_owned();
+    if let Some(fresh) = accounts::try_refresh(&creds, &refresh_token) {
+        let wrapped = serde_json::json!({ "claudeAiOauth": fresh });
+        let _w = super::store_credentials(&wrapped);
+    }
+}

--- a/crates/cp-orchestrator/src/transport/rest/mod.rs
+++ b/crates/cp-orchestrator/src/transport/rest/mod.rs
@@ -33,6 +33,7 @@ mod releases;
 mod threads;
 pub use backend::Backend;
 pub(crate) use claude_oauth::accounts::{delete_account, list_accounts, store_account, switch_account};
+pub(crate) use claude_oauth::sweep::spawn as spawn_oauth_refresh;
 pub(crate) use claude_oauth::{claude_usage, login_complete, login_start, refresh_login, token_status};
 pub(crate) use config::env_keys::{env_key_reveal, env_key_update, env_keys_list, vault_snapshot};
 pub(crate) use config::it::{it_ca_fingerprint, it_get_identity, it_provisioned, it_set_identity};

--- a/web/src/lib/live/useClaudeUsage.ts
+++ b/web/src/lib/live/useClaudeUsage.ts
@@ -104,27 +104,11 @@ export function useClaudeUsage(polling = true): ClaudeUsage {
     return session ? Math.min(session.percent, 100) : 0
   }, [usage.data?.limits])
 
-  // Auto-refresh when the token expires within 30 minutes. The ref pattern keeps
-  // the effect bound to [tokenStatus.data] without re-subscribing when the
-  // mutation object is recreated; the attempt guard fires once per expiry window.
-  const refreshMutateRef = useRef(refreshMutation.mutate)
-  useEffect(() => {
-    refreshMutateRef.current = refreshMutation.mutate
-  })
-  const autoRefreshAttemptedRef = useRef(false)
-  useEffect(() => {
-    const status = tokenStatus.data
-    if (!status?.valid || status.expires_at == null) return
-    const remaining = status.expires_at - Date.now()
-    if (remaining > 0 && remaining < 30 * 60_000) {
-      if (!autoRefreshAttemptedRef.current) {
-        autoRefreshAttemptedRef.current = true
-        refreshMutateRef.current()
-      }
-    } else {
-      autoRefreshAttemptedRef.current = false
-    }
-  }, [tokenStatus.data])
+  // Token auto-refresh is NOT done here anymore: the orchestrator runs a
+  // server-side sweep that keeps the active token AND every stored account
+  // fresh (within an hour of expiry), regardless of whether any UI is open.
+  // The old popover-scoped useEffect only fired while this surface was mounted,
+  // so it "basically never" ran — removed in favour of the always-on backend.
 
   return {
     tokenStatus,

--- a/yamls/tools/console.yaml
+++ b/yamls/tools/console.yaml
@@ -21,7 +21,7 @@ tools:
       id: "Console panel ID (e.g., 'P11')"
       mode: "Wait mode: 'exit' for process completion, 'pattern' for regex match in output"
       pattern: "Regex pattern to match in output (required when mode='pattern'). Use alternation to catch success AND failure: 'Listening on \\d+|error|panic|EADDRINUSE'. Falls back to literal match if invalid regex."
-      max_wait: "Max wait in seconds, 1-30 (default: 30). On timeout, returns last output lines."
+      max_wait: "Max wait in seconds, 1-60 (default: 60). On timeout, returns last output lines."
 
   console_watch:
     description: |


### PR DESCRIPTION
Two changes on `updates-we`:

### 1. Server-side Claude OAuth auto-refresh sweep (`7780b779`)
Standalone orchestrator thread keeps every Claude account (active slot + all stored accounts) fresh regardless of any open UI. First sweep ~10s after boot, then every 10 min; refreshes any token within an hour of expiry.
- `claude_oauth/sweep.rs` — the thread.
- `accounts.rs` — extracted shared refresh POST into `try_refresh` (was copy-pasted 3x); `maybe_refresh` now threshold-driven.
- `runtime`/`main` — `start_oauth_sweeper` after the driver.
- `useClaudeUsage.ts` — dropped the popover-scoped auto-refresh useEffect (backend owns it now).

Verified live: all 3 stored accounts went Expired -> valid within ~12s of orchestrator boot.

### 2. Memory tl_dr cap raised to 120 while advertising 80 (`db402bfb`)
Real enforced ceiling raised to 120 tokens; the model is still told 80 everywhere, so it self-trims well under the true limit and marginal overruns pass instead of erroring.