### PR TITLE
chore(release): bump on a branch, tag after the merge

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -3,7 +3,21 @@
 # Context Pilot ships as an APPLIANCE, not as crates.io packages. The release
 # act is a `v*` tag: .github/workflows/release.yml turns it into per-arch
 # tarballs plus a minisign-signed `stable.json` on the `channels` branch, which
-# the fleet polls (docs/update-policy.md §5.5).
+# the fleet polls (docs/update-policy.md §5.5). Boxes in `auto` mode apply it
+# in their next 03:00–05:00 window.
+#
+# THE FLOW. The `master-protected` ruleset takes changes into master only
+# through a pull request, so a release run cannot push its own bump commit —
+# an earlier revision of this file tried, and GH013 rejected it:
+#
+#     git checkout -b release/vX.Y.Z
+#     cargo release X.Y.Z --workspace --execute      # bump + commit, nothing more
+#     …open a PR, get it merged…
+#     git tag -a vX.Y.Z -m "Context Pilot vX.Y.Z" <merge-sha>
+#     git push origin vX.Y.Z                         # ← this is the release
+#
+# The tag push is what reaches the fleet. Tags are not covered by the ruleset
+# (it targets branches), so that push goes through where the branch push cannot.
 #
 # The workspace shares one version (`[workspace.package] version`), so all
 # crates move together and a single `v<version>` tag names the release.
@@ -16,20 +30,19 @@ publish = false
 shared-version = true
 consolidate-commits = true
 
-tag = true
-tag-name = "v{{version}}"
-tag-message = "Context Pilot {{tag_name}}"
-
 pre-release-commit-message = "chore(release): v{{version}}"
 
-# `--execute` pushes the bump commit AND the tag straight to origin, so the run
-# is the release: CI signs stable.json and every box in `auto` mode applies it
-# in its next 03:00–05:00 window. There is no confirmation step after this.
-push = true
-push-remote = "origin"
+# No tag from the run. This is not tidiness: cargo-release would tag the
+# pre-merge commit, and master can move on between cutting the branch and
+# merging it — the tag would then name a tree missing whatever landed in
+# between. The tag belongs on the merge commit, placed after the fact.
+tag = false
 
-# Which makes this line the safety net. The tag is the fleet release act, so it
-# must only ever exist on master — without this, a `cargo release --execute`
-# from whatever branch happened to be checked out would tag that branch's tip
-# and promote it to every appliance.
-allow-branch = ["master"]
+# No push either, because it cannot succeed. The ruleset rejects a direct push
+# to master, and git pushes refs atomically, so a rejected branch takes the tag
+# down with it — which is exactly how the v0.2.13 attempt failed.
+push = false
+
+# Bump on a release branch, never on master: a bump committed straight to
+# master is a commit that can never be pushed anywhere.
+allow-branch = ["release/*"]


### PR DESCRIPTION
## Description

Repairs `release.toml`, which described a flow this repository does not permit.

`push = true` assumed cargo-release could push the bump straight to master. The `master-protected` ruleset takes changes only through a pull request, so the v0.2.13 run was rejected with `GH013`, and because git pushes refs atomically the rejected branch took the tag down with it. Nothing reached origin; the run left a bump commit and a tag stranded on a local master.

Worth recording why this was missed: `repos/…/branches/master/protection` returns 404, which reads as "master is unprotected". Rulesets are exposed on `repos/…/rules/branches/master` — a different route entirely.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `push = false` — it cannot succeed, and failing atomically takes the tag with it.
- `tag = false` — load-bearing, not tidiness. cargo-release would tag the **pre-merge** commit, and master can move between cutting the branch and merging it, so the tag would name a tree missing whatever landed in between. The tag belongs on the merge commit.
- `allow-branch = ["release/*"]` — a bump committed to master is a commit that can never be pushed anywhere.
- Dropped `tag-name` / `tag-message` / `push-remote`, now dead. The header comment carries the tag command instead, so the naming stays written down where it is used.

The resulting flow:

```
git checkout -b release/vX.Y.Z
cargo release X.Y.Z --workspace --execute      # bump + commit, nothing more
…PR, merge…
git tag -a vX.Y.Z -m "Context Pilot vX.Y.Z" <merge-sha>
git push origin vX.Y.Z                         # ← this is the release
```

Tags are not covered by the ruleset — it targets branches — so the tag push goes through where the branch push cannot.

## Testing

- [ ] Ran `cargo build --release`
- [ ] Ran `cargo test`
- [x] Manually tested the feature/fix
- [x] Tested on: Linux / bash

Config-only; no Rust, no workflow, no manifest touched.

- Dry run from `fix/release-flow` → `cannot release from branch 'fix/release-flow' as it doesn't match 'release/*'`.
- Dry run from a `release/…` branch → plans the bump, and emits **no** `Tagging` and **no** `Pushing` step (0 occurrences).
- `Publishing <29 crates>` still appears; it is cargo-release's cosmetic step header, not a signal — the per-package `publish = false` is the guard.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Independent of #171, which carries the v0.2.13 bump itself and can merge in either order. #171 was produced by the old config and then moved onto a branch by hand; with this merged, the next release produces that shape on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)