### PR TITLE
feat(web): edit the agent image from the Settings tab (T645)

### DIFF
--- a/.context-pilot/shared/memories.yaml
+++ b/.context-pilot/shared/memories.yaml
@@ -52,6 +52,18 @@
   - architecture
   - meilisearch
   last_edited_ms: 1784202976545
+0bc8b494e067496a:
+  tl_dr: 'T645 SHIPPED: agent image editor added to the Settings > Model (LlmTab) tab. Branch agent-image-in-settings off master. Pure render wiring, no backend. Details in body.'
+  contents: 'User (T645) asked to add agent-image modification to the settings tab. The whole avatar upload path already existed (T338: POST /api/agent/{id}/avatar, avatarUrl, useUploadAvatar, and useAgentModalActions.onAvatarChange/onRandomizeAvatar/avatarBust with DiceBear shuffle). The Controller `c` that LlmTab receives already carried these handlers, so this was PURE presentational wiring (M141: no new logic). Added an AvatarField presentational component to web/src/components/agents/AgentModal/manageBody.tsx and render it atop LlmTab (guarded on c.agent): labelled ''Agent image'' section, native <label htmlFor=agent-settings-avatar> file-picker over a visually-hidden input (accept png/jpeg/gif/webp/svg), Dices randomize badge as a SIBLING of the label. Applies immediately (avatar mutation), no Save needed. manageBody 317 lines. AgentModal/ dir stayed at 7 entries (no new file). Full frontend gate green. GOTCHA: prettier failed first because the hand-written JSX/comment wrapping didn''t match prettier; fixed with `npx prettier --write` (that bypasses Edit-tool callbacks, so re-ran the full gate manually).'
+  importance: medium
+  labels:
+  - T645
+  - avatar
+  - agent-image
+  - settings
+  - shipped
+  - web
+  last_edited_ms: 1787827344066
 0c509f3ad4df7597:
   tl_dr: 'Reverie supports multiple concurrent sub-agents (one per agent type). HashMap<String, ReverieState> keyed by agent_id. UI shows one card per active reverie. Tool cap: 50.'
   contents: 'HashMap<String, ReverieState> keyed by agent_id. UI shows one card per active reverie. Built-in: cleaner (context optimizer), cartographer (tree describer). Tool cap: 50.'

--- a/.context-pilot/shared/tree-descriptions.yaml
+++ b/.context-pilot/shared/tree-descriptions.yaml
@@ -6734,6 +6734,10 @@
   path: crates/cp-mod-tree/src/types.rs
   description: Tree state types. TreeFileDescription (path, description, file_hash). TreeState (filter, open_folders, descriptions). DEFAULT_TREE_FILTER constant.
   last_edited_ms: 0
+4c66f21540664329:
+  path: web/src/components/agents/AgentModal/manageBody.tsx
+  description: 'AgentModal manage-mode body (T617): ConfigPanel-style rail (Identity/Model/Vitals from tabs.ts) + detail pane. IdentityTab = 10 Agora fields, render-phase pristine-sync (not effect), saves via set_identity bridge command. LlmTab = agent-image editor (AvatarField) + name/realm/ModelPicker. VitalsTab = SessionVitals + AgentAclSection. T645: AvatarField added atop LlmTab — labelled ''Agent image'' section (native <label> file-picker over hidden input + Dices randomize badge sibling), reusing c.avatarBust/onAvatarChange/onRandomizeAvatar from useAgentModalActions (no logic dup, M141); applies immediately, no save.'
+  last_edited_ms: 1787827333532
 4c6e6d76c577d3c9:
   path: web/src/lib/api/index.ts
   description: 'REST API client barrel: fleet/agent/threads/panels/memory/todos/spine/queue/scratchpad/tree/callbacks/tools/radar/entities/metrics/vitals/usage/library + commands (sendCommand) + mintTicket + renameAgent + avatar CRUD + createCommand. Type re-exports from generated/types.gen (AgentMetrics, Vital, CreateAgentReceipt, RestartReceipt, RetireReceipt, UnretireReceipt, CommandReceipt, CreateCommandReceipt, RadarData). Re-exports ./auth + ./finder + ./body + ./env-keys. The @/lib/api single import surface.'

--- a/web/src/components/agents/AgentModal/manageBody.tsx
+++ b/web/src/components/agents/AgentModal/manageBody.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react"
-import { Loader2, FolderGit2, ScrollText } from "lucide-react"
+import { Loader2, FolderGit2, ScrollText, Dices, ImagePlus } from "lucide-react"
 import { useIdentity, sendCommand } from "@/lib/live"
-import type { AgentIdentity } from "@/lib/api"
+import { avatarUrl, type AgentIdentity } from "@/lib/api"
+import type { Agent } from "@/lib/types"
 import { ModelPicker } from "../ModelPicker"
 import { AgentAclSection } from "../../auth/AgentAclSection"
 import { SessionVitals } from "../../shell/SessionVitals"
@@ -61,13 +62,99 @@ export function TabbedManageBody({ c }: { c: Controller }) {
 
 // ── Model tab ─────────────────────────────────────────────────────────
 
+/**
+ * Agent image editor — the same avatar affordance the create/manage dialog
+ * carries in its header, surfaced as a labelled settings field. The whole
+ * upload path (file pick, DiceBear randomize, cache-bust) lives in
+ * {@link useAgentModalActions}; this only renders it, so there is no logic
+ * duplication (M141) — a manual pick and a random shuffle land the bytes
+ * through the exact same mutation.
+ *
+ * The avatar wrapper is a native `<label>` over a visually-hidden file input:
+ * activating it opens the picker with no ref, no onClick, keyboard-accessible
+ * for free. The Dices badge is a SIBLING of the label (not a descendant) so
+ * shuffling never also trips the label's file dialog.
+ */
+function AvatarField({
+  agent,
+  avatarBust,
+  onAvatarChange,
+  onRandomizeAvatar,
+}: {
+  agent: Agent
+  avatarBust: number
+  onAvatarChange: (file: File) => void
+  onRandomizeAvatar: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-[10.5px] font-semibold tracking-[0.07em] text-muted-foreground/80 uppercase">
+        Agent image
+      </span>
+      <div className="flex items-center gap-3.5">
+        <div className="relative size-16 shrink-0">
+          <label
+            htmlFor="agent-settings-avatar"
+            title="Click to change the agent image"
+            className="flex size-16 cursor-pointer items-center justify-center overflow-hidden rounded-2xl bg-(--signal)/14 text-(--signal) ring-1 ring-(--signal)/25 transition-opacity ring-inset hover:opacity-80"
+          >
+            {agent.hasAvatar ? (
+              <img
+                src={avatarUrl(agent.id, avatarBust || undefined)}
+                alt={agent.name}
+                className="size-16 rounded-2xl object-cover"
+              />
+            ) : (
+              <ImagePlus className="size-6" />
+            )}
+          </label>
+          <input
+            id="agent-settings-avatar"
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+            className="sr-only"
+            onChange={(e) => {
+              const file = e.target.files?.[0]
+              if (file) onAvatarChange(file)
+              e.target.value = ""
+            }}
+          />
+          {/* Sibling of the label, so a shuffle never also opens the picker. */}
+          <button
+            type="button"
+            onClick={onRandomizeAvatar}
+            title="Shuffle a random image"
+            aria-label="Shuffle a random image"
+            className="absolute -right-1.5 -bottom-1.5 flex size-6 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors hover:border-(--signal)/40 hover:text-(--signal)"
+          >
+            <Dices className="size-3" />
+          </button>
+        </div>
+        <span className="text-[12px] leading-relaxed text-muted-foreground/70">
+          Click the image to upload a PNG, JPG, GIF, WebP or SVG — or shuffle for a random one. It
+          applies immediately, no save needed.
+        </span>
+      </div>
+    </div>
+  )
+}
+
 /** Name (rename) + realm preview + provider/model picker — the fields the
  *  footer's Save button persists (configure + rename). In the settings VIEW
- *  there is no footer, so that surface renders its own save bar beside this. */
+ *  there is no footer, so that surface renders its own save bar beside this.
+ *  The agent image editor leads the form (it commits on its own, immediately). */
 export function LlmTab({ c }: { c: Controller }) {
   const { name, setName, realm, providers, provId, modelId, setSel } = c
   return (
     <div className="flex flex-col gap-5 px-6 py-5">
+      {c.agent && (
+        <AvatarField
+          agent={c.agent}
+          avatarBust={c.avatarBust}
+          onAvatarChange={c.onAvatarChange}
+          onRandomizeAvatar={c.onRandomizeAvatar}
+        />
+      )}
       <div className="flex flex-col gap-2">
         <span className="text-[10.5px] font-semibold tracking-[0.07em] text-muted-foreground/80 uppercase">
           Agent name


### PR DESCRIPTION
Adds agent-image editing to the agent **Settings → Model** pane.

## What
A new \`AvatarField\` renders at the top of \`LlmTab\`:
- a native \`<label>\` file-picker over a visually-hidden input (accepts PNG / JPG / GIF / WebP / SVG),
- a **Dices** shuffle badge (sibling of the label, so shuffling never also opens the file dialog) for a random DiceBear image.

The image **applies immediately** through the avatar mutation — no Save needed — matching the manage dialog's behaviour.

## No new logic (M141)
The whole upload path (file pick, DiceBear randomize, cache-bust) already existed in \`useAgentModalActions\` (T338: \`POST /api/agent/{id}/avatar\`, \`avatarUrl\`, \`useUploadAvatar\`). Those handlers are already carried on the Controller \`LlmTab\` receives, so this is **pure presentational wiring** — no duplicated logic, no backend change.

## Gate
Full local frontend gate green: eslint · prettier · stylelint · tsc · type-coverage · suppressions · rule-census · knip. \`manageBody.tsx\` at 317 lines; \`AgentModal/\` dir unchanged at 7 entries (no new file).

Branched off \`master\`.