### PR TITLE
fix(threads): focused-idle thread auto-reads instead of notifying (T697)

### DIFF
--- a/.context-pilot/shared/memories.yaml
+++ b/.context-pilot/shared/memories.yaml
@@ -510,10 +510,10 @@ M-short-6:
   last_edited_ms: 0
 M-short-7:
   tier: short
-  title: T692 auto-read fix
-  contents: 'T692 (todo-v3-yaml-diffs, check_my_turn_threads @ src/app/run/threads/mod.rs): Send(still_my_turn=false) pins focus (T683) so focus ~never None -> old `focus.is_none()` auto-read gate was DEAD. FIX: auto-read fires when FREE = unfocused OR focused thread not itself MY_TURN. Passive notif only when focused on a DIFFERENT MY_TURN thread.'
+  title: T697 focused auto-read
+  contents: 'check_my_turn_threads @ src/app/run/threads/mod.rs. T697 SHIPPED (a9b19094, todo-v3-yaml-diffs): focused+idle+MY_TURN thread now auto-reads ITSELF (waiting prefers focused), DEBOUNCED on notified_my_turn_id vs self-loop. apply_send_message clears notified_my_turn_id (re-arm) instead of focused_thread_input notif. Old T692 free-only rule + passive notif branch removed.'
   importance: high
-  last_edited_ms: 1787951012233
+  last_edited_ms: 1787996890804
 M-short-8:
   tier: short
   title: 'OPERATING MODEL: harbor'

--- a/.context-pilot/shared/tree-descriptions.yaml
+++ b/.context-pilot/shared/tree-descriptions.yaml
@@ -7658,6 +7658,10 @@
   path: crates/cp-orchestrator/src/transport/rest/env_keys.rs
   description: 'On-demand env-key inspection (T399). KNOWN_KEYS whitelist prevents arbitrary env-var enum. env_keys_list(): GET /api/env-keys returns [{env,label,exists}] — no values. env_key_reveal(name): GET /api/env-keys/{name} returns masked value (first-4 + last-4, middle dots) — admin-only when auth active, 404 for unknown keys. mask_key helper. 5 unit tests.'
   last_edited_ms: 1782340075518
+505f0a5947cc9613:
+  path: .git/index
+  description: Git index (binary). Not source.
+  last_edited_ms: 0
 506e44ef1c930cd0:
   path: src/app/run/tools/cleanup.rs
   description: Watcher polling (blocking sentinel replacement + async spine notifications), ASYNC_ERROR_PREFIX handling for is_error, DynPanel creation for both blocking/async paths, interrupt cleanup. Blocking path now calls accumulate_pending_token_stats + append_cost_tsv (T478 fix). flame!("watchers"). No PendingForm references.
@@ -13218,6 +13222,10 @@
   path: crates/cp-orchestrator/src/transport/rest/releases.rs
   description: 'Release mgmt REST (T427): list/set_arch/download/select/delete/deploy_fleet/restart_orchestrator. releases_break_glass gate (410 unless CP_RELEASES_BREAK_GLASS). restart_orchestrator=stage cp-orchestrator over install path + execv re-exec (abort() fallback). orch-clippy: NOT yet cleaned.'
   last_edited_ms: 1787881790074
+8b113cc3ed6da9cb:
+  path: .context-pilot/shared/memories.yaml
+  description: Memory slots store (M-safe/tiny/short/mid/long, 220 fixed). Local-only, synced with commits. Mirrors the Memories panel.
+  last_edited_ms: 0
 8b1e52307d030d8d:
   path: crates/cp-mod-files/src/tools/write.rs
   description: file_write tool. flame!("file_write"). Creates parent dirs, writes content, updates/creates context Entry. Diff-style preview in result (first 20 lines).
@@ -14826,6 +14834,10 @@
   path: ui/src/components/agents/FleetShell.tsx
   description: 'Fleet mission-control shell. Owns fleetPage + collapsed state. Renders FleetSidebar + a clickable border RAIL (shadcn Sidebar pattern): thin full-height hit area at x=SIDEBAR_W(212), tracks width, sits at x=0 when collapsed, brightens to interactive on hover — click toggles collapse (no buttons). Active page: agents/prompts/usage/settings(ConfigPanel inline).'
   last_edited_ms: 1781532872888
+9d1f309a09e072b4:
+  path: src/app/run/threads/commands.rs
+  description: Bridge command APPLICATION (K7 mutation half). apply_command dispatches Send/Create/Archive/Restore/Pause/Resume/Delete thread + DeleteMessage (collect_delete_timestamps helper, A2) + Stop/Configure. Focused-thread instant spine notif.
+  last_edited_ms: 0
 9d20b15ef58729cf:
   path: crates/cp-mod-spine/src/tools.rs
   description: Spine tool handlers. execute_mark_processed (batch notification marking), execute_configure (guard rail limits with zero-value rejection, counter reset).
@@ -17321,6 +17333,10 @@ b621877dc6de956c:
 b6256b5251aeb829:
   path: src/app/run/lifecycle.rs
   description: 'Main event loop with flame!("loop"). Input-first design (non-blocking poll). Background: stream events, tools, cache, watchers, spine, reverie. Ownership checks. Render at ~28fps. Adaptive poll: 8ms streaming, 50ms idle. Time-based spinner dirty tick (100ms).'
+  last_edited_ms: 0
+b62ba412b3d565d5:
+  path: web/src/components/threads/ThreadList.tsx
+  description: Thread sidebar list. Grouped by turn-status (Agent's turn / User turn) + Archived view. Search now lives in ThreadSearchPalette (T669) opened from ListHeader's Search button; ListHeader also has a PanelLeftClose sidebar-collapse button. Row-hover title marquee via useTitleMarquee (WAA). Subcomponents RowActions/RowMeta/ListHeader/EmptyState keep budgets. Exactly 500 lines (cap).
   last_edited_ms: 0
 b631a45d56d3e8dc:
   path: web/src/components/shell/config/ReleasesPane.tsx
@@ -20465,6 +20481,10 @@ d7f947737a248243:
 d8145eaa81b7194a:
   path: web/src/components/shell/TopBar.tsx
   description: 'Slim macOS-style title bar (T321 trimmed): app mark→fleet, agent switcher, per-agent view tabs (Threads/Finder/Cockpit/Costs), agent-config gear, UsageButton, account UserMenu. Costs tab dev-mode only. P8: view-tab cluster extracted into a ViewTabs subcomponent (moving the two devMode gates off TopBar''s complexity budget); TopBar fn now <150 lines / cx<15.'
+  last_edited_ms: 0
+d817adc3abb8d21e:
+  path: src/app/run/threads/mod.rs
+  description: 'Thread helpers for main loop: maybe_inject_auto_read (filters paused threads — T371), check_my_turn_threads (filters paused threads — T371), extract_thread_ids, maybe_append_tool_activity. emit_thread_paused re-exported from paused.rs.'
   last_edited_ms: 0
 d81fe2ee7ef0a5d1:
   path: web/src/components/shell/TopBar.tsx

--- a/src/app/run/threads/commands.rs
+++ b/src/app/run/threads/commands.rs
@@ -11,7 +11,7 @@ use cp_base::config::llm_types::LlmProvider;
 use cp_base::config::models::{AnthropicModel, ClaudeCodeV2Model, DeepSeekModel, GrokModel, GroqModel, MiniMaxModel};
 use cp_base::state::runtime::State;
 use cp_mod_bridge::BridgeState;
-use cp_mod_spine::types::{NotificationType, SpineState};
+use cp_mod_spine::types::SpineState;
 use cp_mod_threads::types::{FocusState, ThreadAuthor, ThreadMessage, ThreadStatus, ThreadsState};
 use cp_wire::types::command::{Command, Kind as CommandKind};
 use cp_wire::types::oplog::OpEntryKind;
@@ -83,26 +83,20 @@ fn apply_send_message(state: &mut State, thread_id: &str, content: &str) {
 
     thread.messages.push(ThreadMessage::user(content.to_owned()));
     thread.status = ThreadStatus::MyTurn;
-    let thread_name = thread.name.clone();
 
     // No instant spine notification for unfocused threads — the idle
     // MY_TURN detection (`check_my_turn_threads`) handles it when the
     // agent finishes, avoiding mid-task distraction.
     //
-    // Exception: if the message lands on the CURRENTLY FOCUSED thread,
-    // fire immediately — the user is actively talking to the agent in the
-    // thread it's working on and expects a quick acknowledgement.
+    // Focused-thread case (T697): the user just messaged the thread the agent is
+    // parked on. Rather than firing a redundant `focused_thread_input`
+    // notification (a "go Read + ack" nudge), **re-arm** the idle auto-read by
+    // clearing the MY_TURN debounce. `check_my_turn_threads` then reads the
+    // focused thread directly the moment the agent is idle (immediately if not
+    // streaming, or as soon as the current stream ends), turning every new
+    // message on the focused thread into exactly one direct auto-read.
     if FocusState::get(state).focused_thread_id.as_deref() == Some(thread_id) {
-        let notif = format!(
-            "The user has just sent a NEW message to your currently focused thread \
-             \"{thread_name}\" ({thread_id}):\n\n\
-             {content}\n\n\
-             Please acknowledge QUICKLY:\n\
-             1. Read(thread_id=\"{thread_id}\") to refresh the conversation\n\
-             2. Send a short acknowledgement (still_my_turn=true)",
-        );
-        let _r =
-            SpineState::create_notification(state, NotificationType::Custom, "focused_thread_input".to_owned(), notif);
+        FocusState::get_mut(state).notified_my_turn_id = None;
     }
 
     for module in crate::modules::all_modules() {

--- a/src/app/run/threads/mod.rs
+++ b/src/app/run/threads/mod.rs
@@ -22,7 +22,6 @@ pub(super) use paused::emit_thread_paused;
 use crate::app::App;
 use crate::app::PendingDone;
 use cp_base::tools::ToolUse;
-use cp_mod_spine::types::{NotificationType, SpineState};
 use cp_mod_threads::types::{FocusState, ThreadMessage, ThreadStatus, ThreadsState};
 
 /// Run every bridge live-emission chokepoint for one main-loop tick — the
@@ -171,24 +170,28 @@ pub(super) fn inject_tool_call(app: &mut App, tool: ToolUse) {
     app.pending_done = Some(synthetic_done);
 }
 
-/// Handle an idle thread that has `MY_TURN` status (T692).
+/// Handle an idle thread that has `MY_TURN` status (T692, extended T697).
 ///
-/// The response is **momentum-first**: when the agent is **free** — unfocused,
-/// or focused on a thread that is itself parked (`THEIR_TURN`, e.g. one just
-/// handed back via `Send(still_my_turn=false)`, which pins focus on it per T683)
-/// — this directly auto-injects the `Read` on a waiting `MY_TURN` thread (the
-/// natural next tool call) and creates **no** spine notification. The
-/// notification is a **passive** fallback, created only when the agent is
-/// genuinely mid-work — i.e. focused on a *different* thread that is itself
-/// `MY_TURN`.
+/// Reaching the body means the agent is **idle** (the top `is_streaming` guard
+/// returns otherwise), so it directly auto-injects a `Read` on the thread that
+/// needs a response — the natural next tool call — and creates **no** spine
+/// notification. Two cases, in priority order:
 ///
-/// Previously the auto-Read only happened as a side-effect of the
-/// notification→auto-continuation chain in [`check_spine`](crate::app::run) via
-/// [`maybe_inject_auto_read`]; making the `MY_TURN` detector drive it directly
-/// removes that fragile coupling and lets the notification be skipped entirely.
+///  1. **Focused + idle on a `MY_TURN` thread** — a new user message landed on
+///     the thread I'm parked on (T697). Auto-read *that* thread. Debounced via
+///     `FocusState::notified_my_turn_id` so re-reading the focused thread (which
+///     keeps focus on it) can't loop on a kept-turn / no-response idle tick; the
+///     debounce is cleared on hand-back (`execute_send` `still_my_turn=false`) and
+///     re-armed when a fresh user message arrives (`apply_send_message`).
+///  2. **Free** (unfocused, or focused on a `THEIR_TURN` thread) with a
+///     different `MY_TURN` thread waiting — auto-read it. Not debounced: the
+///     injected Read re-focuses onto it (next tick it becomes case 1), which
+///     prevents re-entry, so a stale/persisted `notified_my_turn_id` never
+///     suppresses it.
 ///
-/// Debounced via `FocusState::notified_my_turn_id` — fires once per thread
-/// transition to `MY_TURN`, cleared when the AI replies (thread → `THEIR_TURN`).
+/// Previously the focused-thread case fired a `focused_thread_input`
+/// notification (a "go Read + ack" nudge) instead of reading directly; making
+/// the detector own the focused case removes that redundant round-trip.
 pub(super) fn check_my_turn_threads(app: &mut App) {
     if app.state.flags.stream.phase.is_streaming() {
         return;
@@ -197,69 +200,56 @@ pub(super) fn check_my_turn_threads(app: &mut App) {
     let threads = ThreadsState::get(&app.state);
     let focus = FocusState::get(&app.state).focused_thread_id.clone();
 
-    // Am I actively working a demanding thread right now? "Demanding" = the
-    // thread I'm focused on is ITSELF MY_TURN (it still needs my response). Being
-    // focused on a THEIR_TURN thread (one I just handed back via
-    // `Send(still_my_turn=false)`, which pins focus on it per T683) is NOT active
-    // work — I'm parked waiting on the user, so I'm free to pick up another
-    // waiting thread. This is the crux of the fix: post-T683 focus is (almost)
-    // never `None`, so gating auto-read on `focus.is_none()` made it dead code.
+    // The waiting thread to auto-read, chosen with the FOCUSED thread PREFERRED:
+    // if the thread I'm parked on is itself MY_TURN (the user just messaged the
+    // thread I'm sitting on), that's the one to read first (T697). Otherwise fall
+    // back to any other eligible MY_TURN thread. Reaching this point means we are
+    // NOT streaming (top guard), i.e. idle — so "focused on a MY_TURN thread" is
+    // not "busy mid-work", it's "parked on a thread that now needs my response".
     // Archived/paused threads are LLM-invisible (T9/T371) and never count.
-    let focused_is_my_turn = focus.as_deref().is_some_and(|f| {
-        threads.threads.iter().any(|t| t.id == f && !t.archived && !t.paused && t.status == ThreadStatus::MyTurn)
-    });
-
-    // The waiting thread: the first eligible MY_TURN thread that is NOT the one
-    // I'm already focused on (so I never "auto-read" my own active thread).
-    let waiting = threads.threads.iter().find(|t| {
-        !t.archived && !t.paused && t.status == ThreadStatus::MyTurn && Some(t.id.as_str()) != focus.as_deref()
-    });
+    let eligible = |t: &&cp_mod_threads::types::Thread| !t.archived && !t.paused && t.status == ThreadStatus::MyTurn;
+    let waiting = focus
+        .as_deref()
+        .and_then(|f| threads.threads.iter().find(|t| t.id == f && eligible(t)))
+        .or_else(|| threads.threads.iter().find(eligible));
 
     let Some(thread) = waiting else {
-        // No OTHER MY_TURN thread — clear debounce.
+        // No MY_TURN thread — clear debounce.
         FocusState::get_mut(&mut app.state).notified_my_turn_id = None;
         return;
     };
 
     let tid = thread.id.clone();
     let tname = thread.name.clone();
+    let is_focused_thread = Some(tid.as_str()) == focus.as_deref();
 
-    // Free (unfocused OR focused thread is parked/THEIR_TURN) → auto-Read the
-    // waiting thread directly, no notification. The debounce is deliberately NOT
-    // read as a guard here: the auto-read path is guarded against re-entry by the
-    // `is_streaming` check at the top (it begins streaming) and by the injected
-    // Read focusing the thread, so a stale/persisted `notified_my_turn_id`
-    // (e.g. carried across a reload) must never suppress it.
-    if !focused_is_my_turn {
+    // Case 1 — the waiting thread IS the one I'm focused on (focused + idle +
+    // MY_TURN): auto-read it directly (T697). This is the case a new message on
+    // the thread I'm parked on used to fire a redundant "go Read + ack"
+    // notification for. It is DEBOUNCED on `notified_my_turn_id`: re-reading the
+    // focused thread keeps focus on it, so without the guard a kept-turn or
+    // no-response idle tick would re-read it forever. The debounce is cleared
+    // when I hand the thread back (`execute_send` still_my_turn=false) and
+    // re-armed when a new user message lands (`apply_send_message`), so each
+    // fresh user message triggers exactly one auto-read.
+    if is_focused_thread {
+        if FocusState::get(&app.state).notified_my_turn_id.as_deref() == Some(tid.as_str()) {
+            return;
+        }
         FocusState::get_mut(&mut app.state).notified_my_turn_id = Some(tid.clone());
         inject_direct_auto_read(app, &tid, &tname);
         return;
     }
 
-    // Focused on a DIFFERENT thread that is ITSELF MY_TURN (genuinely mid-work)
-    // → we can't hijack focus, so leave a PASSIVE
-    // nudge instead of an active trigger. The `my_turn_thread` notification is
-    // created **already-processed** so the spine never auto-continues on it —
-    // an active one would interrupt the focused work with a "go read T…" nudge,
-    // the exact mid-task distraction the design avoids (see `apply_send_message`).
-    // It stays visible in the Spine panel/history for the human; the thread is
-    // actually read by the direct auto-read the instant the agent becomes
-    // idle+unfocused. Debounced purely on `notified_my_turn_id` so it's posted
-    // once per transition (the presence of a now-passive notification can no
-    // longer be used as the debounce signal).
-    if FocusState::get(&app.state).notified_my_turn_id.as_deref() == Some(tid.as_str()) {
-        return;
-    }
+    // Case 2 — I'm free (focused thread is not MY_TURN, or unfocused) and a
+    // DIFFERENT thread is MY_TURN → auto-Read it directly, no notification. The
+    // debounce is deliberately NOT read as a guard here: re-entry is prevented by
+    // the `is_streaming` check at the top (this begins streaming) and by the
+    // injected Read re-focusing onto that thread (so next tick it is the focused
+    // thread, handled by Case 1's debounce), so a stale/persisted
+    // `notified_my_turn_id` (e.g. carried across a reload) must never suppress it.
     FocusState::get_mut(&mut app.state).notified_my_turn_id = Some(tid.clone());
-
-    let content = format!(
-        "Thread \"{tname}\" ({tid}) is MY_TURN — it has user input awaiting your response. \
-         It will be auto-read the moment you're free; no action needed now.",
-    );
-    let nid =
-        SpineState::create_notification(&mut app.state, NotificationType::Custom, "my_turn_thread".to_owned(), content);
-    // Passive: mark processed immediately so it never triggers auto-continuation.
-    let _found = SpineState::mark_notification_processed(&mut app.state, &nid);
+    inject_direct_auto_read(app, &tid, &tname);
 }
 
 /// Directly drive an auto-Read on `tid` from the idle `MY_TURN` detector (T692).


### PR DESCRIPTION
## What

When the agent is **focused on a thread and idle**, a new user message on that thread now triggers a **direct auto-read** instead of a redundant `focused_thread_input` notification (a "go Read + ack" nudge).

## Why

The focused-thread notification path predated the T692 direct-auto-read work, which only ever handled the *unfocused* / *different-thread* case. `check_my_turn_threads` explicitly excluded the focused thread from its candidate search, so the thread you were parked on was structurally ineligible for auto-read — it always fell back to the notification.

## Changes

- **`check_my_turn_threads`** (`src/app/run/threads/mod.rs`): the waiting-thread search now **prefers the focused thread** when it is itself `MY_TURN`. That case auto-reads directly, **debounced on `notified_my_turn_id`** so re-reading the focused thread (which keeps focus on it) cannot loop on a kept-turn / no-response idle tick. The old free-only rule + the now-dead passive `my_turn_thread` notification branch are removed.
- **`apply_send_message`** (`src/app/run/threads/commands.rs`): a new message on the focused thread now **re-arms** the idle auto-read (clears `notified_my_turn_id`) instead of firing the `focused_thread_input` notification.

## Verification

- `check-rust-lints.sh --ci` green: fmt · clippy · check · exceptions · vault ✓
- Built `tui` + reloaded; fix is live.
