### PR TITLE
feat(bridge,orch): move runtime artifacts to global ~/.context-pilot/sync/<id>/ (T713)

### DIFF
--- a/.context-pilot/shared/memories.yaml
+++ b/.context-pilot/shared/memories.yaml
@@ -75,6 +75,12 @@ M-long-7:
   title: NEVER touch temp_1.md or
   importance: critical
   last_edited_ms: 1787840930958
+M-long-8:
+  tier: long
+  title: T713 sync-dir plan
+  contents: 'T713 SHIPPING (branch t713-sync-dir off master). Move bridge.lock/heartbeat/stream.sock/tee.sock/oplog -> GLOBAL ~/.context-pilot/sync/<id>/ (id=folder_id FNV-1a). cp-wire Entry gained tee_socket_path #[serde(default)] (14->15 fields). Orch: driver.rs resolve_tee_path (field else folder+tee.sock), TeeReader::spawn full path, reap_orphan_sync_dirs grace=7d (DEFAULT_SYNC_ORPHAN_GRACE=Duration::from_hours(168)). Agent boot/mod.rs start_inner: BootDirs{agents_dir,sync_root} param struct, create_dir_all sync_dir before lock, all 5 artifacts under sync_dir, migrate::migrate_oplog one-time (rename+EXDEV copy/fsync/remove). registry::default_sync_root helper. boot tests moved to boot/tests.rs (500-line cap). PHASE 4 COMPLETE: build+tests+workspace-clippy+api-contract ALL GREEN. Next: commit+push+PR (orch-first deploy M177).'
+  importance: critical
+  last_edited_ms: 1788349943018
 M-long-9:
   tier: long
   title: MULTI-WORKER (subworkers

--- a/.github/checks/allowed-lint-exceptions.yaml
+++ b/.github/checks/allowed-lint-exceptions.yaml
@@ -378,10 +378,10 @@ exceptions:
   # these two are the irreducible remainder.
 
   - path: "crates/cp-wire/src/types/registry.rs"
-    match: "registry-record contract: Entry is a 14-field agent discovery record"
+    match: "registry-record contract: Entry is a 15-field agent discovery record"
     reason: >
-      Entry is a 14-field agent discovery record written cross-crate by the bridge boot path and
-      read field-by-field by the backend; a constructor would take 13 positional arguments
+      Entry is a 15-field agent discovery record written cross-crate by the bridge boot path and
+      read field-by-field by the backend; a constructor would take 14 positional arguments
       (tripping too_many_arguments) with no natural grouping, so #[non_exhaustive] is impossible.
     strategy: >
       Irreducible — a 13-arg constructor trips too_many_arguments; the exhaustive literal is honest.

--- a/.github/checks/lint-config.chain
+++ b/.github/checks/lint-config.chain
@@ -8111,3 +8111,24 @@ index d551b7b1..70e88880 100644
    # The read-plane mirror of the command contracts above: query Kind is built
    # by the orchestrator and matched exhaustively by the agent (Unknown catch-all
 # --- End entry #94 ---
+95:897cf24a54c59b5a79b7e6c74c61357e5b211abda342d47acf2d0e03b37d4cbd:a6650fa86d9dab031d33e3ac9a481bd926fb3b32f18f2f96d20a4ec2d0b3cea2:32069235c73bbd87766dba5ef6b1e0503fd41a48b520328d63c2b03ce16c03dc
+# --- Diff for entry #95 ---
+diff --git a/.github/checks/allowed-lint-exceptions.yaml b/.github/checks/allowed-lint-exceptions.yaml
+index 70e88880..8927b050 100644
+--- a/.github/checks/allowed-lint-exceptions.yaml
++++ b/.github/checks/allowed-lint-exceptions.yaml
+@@ -378,10 +378,10 @@ exceptions:
+   # these two are the irreducible remainder.
+ 
+   - path: "crates/cp-wire/src/types/registry.rs"
+-    match: "registry-record contract: Entry is a 14-field agent discovery record"
++    match: "registry-record contract: Entry is a 15-field agent discovery record"
+     reason: >
+-      Entry is a 14-field agent discovery record written cross-crate by the bridge boot path and
+-      read field-by-field by the backend; a constructor would take 13 positional arguments
++      Entry is a 15-field agent discovery record written cross-crate by the bridge boot path and
++      read field-by-field by the backend; a constructor would take 14 positional arguments
+       (tripping too_many_arguments) with no natural grouping, so #[non_exhaustive] is impossible.
+     strategy: >
+       Irreducible — a 13-arg constructor trips too_many_arguments; the exhaustive literal is honest.
+# --- End entry #95 ---

--- a/crates/cp-mod-bridge/src/boot/activate.rs
+++ b/crates/cp-mod-bridge/src/boot/activate.rs
@@ -19,16 +19,16 @@ use crate::tee::Tee;
 
 use super::Boot;
 
-/// Name of the dedicated tee socket inside the agent folder.
+/// Bind the agent's advertised tee socket and spawn the [`Tee`] publisher.
 ///
-/// Separate from `stream.sock` (which Boot binds for command intake in Phase
-/// 10). The tee socket carries only outbound [`StreamFrame`]s to an observing
-/// backend.
-const TEE_SOCKET: &str = "tee.sock";
-
-/// Bind `tee.sock` in the agent folder and spawn the [`Tee`] publisher.
+/// The tee socket path comes straight from the registry [`Entry`]'s
+/// `tee_socket_path` (T713) — it now lives under the global
+/// `~/.context-pilot/sync/<id>/`, not the realm folder, so it can no longer be
+/// reconstructed by name from `entry.folder`. Separate from `stream.sock`
+/// (Boot's command-intake socket); this one carries only outbound
+/// [`StreamFrame`]s to an observing backend.
 fn setup_tee(entry: &cp_wire::types::registry::Entry) -> std::io::Result<Tee> {
-    let tee_path = std::path::Path::new(&entry.folder).join(TEE_SOCKET);
+    let tee_path = std::path::PathBuf::from(&entry.tee_socket_path);
     let _ignored = std::fs::remove_file(&tee_path);
     let listener = std::os::unix::net::UnixListener::bind(&tee_path)?;
     Ok(Tee::spawn(listener))

--- a/crates/cp-mod-bridge/src/boot/migrate.rs
+++ b/crates/cp-mod-bridge/src/boot/migrate.rs
@@ -1,0 +1,123 @@
+//! One-time relocation of a pre-T713 oplog from the realm folder into the
+//! global sync dir (`~/.context-pilot/sync/<id>/oplog`).
+//!
+//! Before T713 an agent's durable oplog lived at `<realm>/oplog`. With the sync
+//! plane moved to `$HOME`, an existing agent must carry its oplog across on the
+//! first boot after the upgrade — otherwise it starts a *fresh* log (command
+//! dedup resets, and the message chokepoint could re-emit a `MessageCreated`
+//! backlog). [`migrate_oplog`] performs that move exactly once, and is a no-op
+//! for a brand-new agent (no old oplog) or one already migrated (new oplog
+//! present).
+//!
+//! # Cross-device safety
+//!
+//! `rename(2)` is atomic and cheap only *within one filesystem*. With the global
+//! location the realm (possibly on an external/removable drive or a different
+//! mount) and `$HOME` can be on different devices, where `rename` fails with
+//! `EXDEV`. So on any rename failure we fall back to a recursive **copy +
+//! `fsync` + remove**: every file is copied and `fsync`'d, the destination tree
+//! is `fsync`'d, and only then is the source removed — so a crash mid-migration
+//! leaves the source intact (the move is re-attempted next boot) rather than a
+//! half-moved, corrupt log.
+
+use std::fs::{self, File};
+use std::path::Path;
+
+use crate::error::{BootResult, Error};
+
+/// Move a pre-T713 `<realm>/oplog` to its new sync-dir location `new`, exactly
+/// once. No-op when `new` already exists (already migrated) or `old` is absent
+/// (a brand-new agent). Tries an atomic `rename` first, falling back to a
+/// durable cross-device copy when the two paths straddle a filesystem boundary.
+///
+/// # Errors
+///
+/// Returns [`Error::Io`] if the relocation fails (rename error other than a
+/// cross-device boundary, or a copy/fsync/remove failure in the fallback).
+pub(super) fn migrate_oplog(old: &Path, new: &Path) -> BootResult<()> {
+    if new.exists() || !old.exists() {
+        return Ok(());
+    }
+
+    // Fast path: an atomic same-filesystem rename.
+    if fs::rename(old, new).is_ok() {
+        return Ok(());
+    }
+
+    // Fallback: the source and destination are on different devices (EXDEV) or
+    // the rename otherwise failed — copy the whole tree durably, then remove the
+    // source. Copying first (and only removing on success) keeps the move
+    // crash-safe: an interrupted copy leaves the original oplog untouched.
+    copy_tree_durable(old, new)
+        .map_err(|e| Error::io(format!("copy oplog {} -> {}", old.display(), new.display()), e))?;
+    fs::remove_dir_all(old).map_err(|e| Error::io(format!("remove migrated oplog {}", old.display()), e))?;
+    Ok(())
+}
+
+/// Recursively copy directory `src` to `dst`, `fsync`ing every copied file and
+/// each created directory so the relocated tree is durable before the caller
+/// removes the source.
+fn copy_tree_durable(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for raw in fs::read_dir(src)? {
+        let dirent = raw?;
+        let from = dirent.path();
+        let to = dst.join(dirent.file_name());
+        if dirent.file_type()?.is_dir() {
+            copy_tree_durable(&from, &to)?;
+        } else {
+            let _copied = fs::copy(&from, &to)?;
+            File::open(&to)?.sync_all()?;
+        }
+    }
+    // fsync the directory so its new entries survive a crash.
+    File::open(dst)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn noop_when_new_exists() {
+        let dir = tempdir().expect("dir");
+        let old = dir.path().join("old-oplog");
+        let new = dir.path().join("new-oplog");
+        fs::create_dir_all(&old).expect("mk old");
+        fs::write(old.join("seg"), b"OLD").expect("seed old");
+        fs::create_dir_all(&new).expect("mk new");
+        fs::write(new.join("seg"), b"NEW").expect("seed new");
+
+        migrate_oplog(&old, &new).expect("migrate");
+        // The already-present new oplog is untouched; the old one is left alone.
+        assert_eq!(fs::read(new.join("seg")).expect("read new"), b"NEW");
+        assert!(old.exists(), "old is not removed when new already exists");
+    }
+
+    #[test]
+    fn noop_when_old_absent() {
+        let dir = tempdir().expect("dir");
+        let old = dir.path().join("old-oplog");
+        let new = dir.path().join("new-oplog");
+        migrate_oplog(&old, &new).expect("migrate");
+        assert!(!new.exists(), "nothing is created when there is no old oplog");
+    }
+
+    #[test]
+    fn moves_tree_with_bodies_and_removes_source() {
+        let dir = tempdir().expect("dir");
+        let old = dir.path().join("old-oplog");
+        let new = dir.path().join("sync").join("id").join("oplog");
+        fs::create_dir_all(old.join("bodies")).expect("mk old/bodies");
+        fs::write(old.join("segment-0"), b"seg-data").expect("seed seg");
+        fs::write(old.join("bodies").join("ab12"), b"body-data").expect("seed body");
+
+        migrate_oplog(&old, &new).expect("migrate");
+
+        assert!(!old.exists(), "source oplog is removed after migration");
+        assert_eq!(fs::read(new.join("segment-0")).expect("read seg"), b"seg-data");
+        assert_eq!(fs::read(new.join("bodies").join("ab12")).expect("read body"), b"body-data");
+    }
+}

--- a/crates/cp-mod-bridge/src/boot/mod.rs
+++ b/crates/cp-mod-bridge/src/boot/mod.rs
@@ -65,17 +65,22 @@ use self::lock::{LOCK_RETRY_ATTEMPTS, acquire_lock};
 
 pub mod activate;
 mod lock;
+mod migrate;
 pub mod seed_state;
 
-/// Name of the oplog directory inside the agent folder.
+/// Name of the oplog directory inside the agent's sync dir.
 const OPLOG_DIR: &str = "oplog";
 
-/// Name of the agent's stream socket inside the agent folder.
+/// Name of the agent's stream socket inside the agent's sync dir.
 const SOCKET_FILE: &str = "stream.sock";
 
-/// Name of the agent's heartbeat file inside the agent folder (written by the
-/// Phase 11 heartbeat thread; boot only records its path).
+/// Name of the agent's heartbeat file inside the agent's sync dir (written by
+/// the Phase 11 heartbeat thread; boot only records its path).
 const HEARTBEAT_FILE: &str = "heartbeat";
+
+/// Name of the agent's live-stream tee socket inside its sync dir. `pub(crate)`
+/// so [`activate`] shares the single name source (T713).
+pub(crate) const TEE_SOCKET: &str = "tee.sock";
 
 /// A booted agent bridge: the held resources plus the registry record that
 /// advertises them.
@@ -105,6 +110,18 @@ pub struct Boot {
     _heartbeat: Beacon,
 }
 
+/// The two location roots [`Boot::start_inner`] writes into, bundled so the
+/// boot body stays within the argument budget: `agents_dir` (where the registry
+/// discovery record is written) and `sync_root` (the parent of the per-agent
+/// `<sync_root>/<id>/` runtime directory — T713).
+#[derive(Clone, Copy)]
+struct BootDirs<'dirs> {
+    /// Directory the `<id>.json` registry record is written into.
+    agents_dir: &'dirs Path,
+    /// Root under which the per-agent sync dir `<sync_root>/<id>/` is created.
+    sync_root: &'dirs Path,
+}
+
 impl Boot {
     /// Boot the bridge for `folder`, advertising `model`, writing the registry
     /// into the default `~/.context-pilot/agents` directory.
@@ -116,7 +133,13 @@ impl Boot {
     /// socket, registry) — or if `$HOME` is unset.
     pub fn start(folder: &Path, model: &str) -> BootResult<Self> {
         let agents_dir = registry::default_agents_dir()?;
-        Self::start_in(folder, &agents_dir, model)
+        let sync_root = registry::default_sync_root()?;
+        Self::start_inner(
+            folder,
+            BootDirs { agents_dir: &agents_dir, sync_root: &sync_root },
+            model,
+            LOCK_RETRY_ATTEMPTS,
+        )
     }
 
     /// Attempt a boot with a **single, non-blocking** lock acquisition — no
@@ -137,43 +160,66 @@ impl Boot {
     /// or [`Error::Io`] for any filesystem failure.
     pub fn try_start(folder: &Path, model: &str) -> BootResult<Self> {
         let agents_dir = registry::default_agents_dir()?;
-        Self::start_inner(folder, &agents_dir, model, 0)
+        let sync_root = registry::default_sync_root()?;
+        Self::start_inner(folder, BootDirs { agents_dir: &agents_dir, sync_root: &sync_root }, model, 0)
     }
 
     /// Boot the bridge writing the registry into an explicit `agents_dir`
-    /// (tests point this at a tempdir so they never touch the real home).
+    /// (tests point this at a tempdir so they never touch the real home). The
+    /// sync-plane root is derived as `agents_dir`'s `sync` sibling — mirroring
+    /// the production `~/.context-pilot/{agents,sync}` layout — so a test's
+    /// runtime artifacts also land in an isolated temp location, never `$HOME`.
     ///
     /// # Errors
     ///
     /// As [`start`](Self::start).
     pub fn start_in(folder: &Path, agents_dir: &Path, model: &str) -> BootResult<Self> {
-        Self::start_inner(folder, agents_dir, model, LOCK_RETRY_ATTEMPTS)
+        let sync_root = agents_dir.parent().map_or_else(|| agents_dir.join("sync"), |parent| parent.join("sync"));
+        Self::start_inner(folder, BootDirs { agents_dir, sync_root: &sync_root }, model, LOCK_RETRY_ATTEMPTS)
     }
 
     /// Shared boot body. `lock_attempts` is the number of *additional* contended
     /// `flock` retries: [`LOCK_RETRY_ATTEMPTS`] for the patient startup path, `0`
-    /// for the fail-fast [`try_start`](Self::try_start) recovery path.
+    /// for the fail-fast [`try_start`](Self::try_start) recovery path. `dirs`
+    /// bundles the two location roots (registry `agents_dir` + `sync_root`) so
+    /// this stays within the argument budget.
+    ///
+    /// All five runtime artifacts (lock, oplog, stream socket, heartbeat, tee
+    /// socket) live under `<sync_root>/<id>/` (T713), not the realm folder —
+    /// keeping the user's project tree clean and bounding the Unix-socket path
+    /// length. The realm folder is still canonicalised (to derive the stable
+    /// `id`) but nothing is written into it.
     ///
     /// # Errors
     ///
     /// As [`start`](Self::start).
-    fn start_inner(folder: &Path, agents_dir: &Path, model: &str, lock_attempts: u32) -> BootResult<Self> {
-        // The folder must exist before we can canonicalise + lock it.
+    fn start_inner(folder: &Path, dirs: BootDirs<'_>, model: &str, lock_attempts: u32) -> BootResult<Self> {
+        let agents_dir = dirs.agents_dir;
+        let sync_root = dirs.sync_root;
+        // The folder must exist before we can canonicalise it (the canonical
+        // path is only used to derive the stable id — nothing is written here).
         fs::create_dir_all(folder).map_err(|e| Error::io(format!("create agent folder {}", folder.display()), e))?;
         let canonical =
             fs::canonicalize(folder).map_err(|e| Error::io(format!("canonicalise {}", folder.display()), e))?;
         let id = folder_id(&canonical.to_string_lossy());
 
-        // 1. The single-process gate — must come first.
-        let lock = acquire_lock(&canonical, lock_attempts)?;
+        // The per-agent sync dir holds every runtime artifact; create it before
+        // acquiring the lock or binding any socket underneath it.
+        let sync_dir = sync_root.join(&id);
+        fs::create_dir_all(&sync_dir).map_err(|e| Error::io(format!("create sync dir {}", sync_dir.display()), e))?;
 
-        // 2. Oplog (opens/creates the dir, spawns the commit thread).
-        let oplog_path = canonical.join(OPLOG_DIR);
+        // 1. The single-process gate — must come first.
+        let lock = acquire_lock(&sync_dir, lock_attempts)?;
+
+        // 2. Oplog. One-time relocation of a pre-T713 `<realm>/oplog` into the
+        //    sync dir (no-op for a new or already-migrated agent), then open it.
+        let oplog_path = sync_dir.join(OPLOG_DIR);
+        migrate::migrate_oplog(&canonical.join(OPLOG_DIR), &oplog_path)?;
         let oplog = OplogService::spawn(&oplog_path)
             .map_err(|e| Error::io(format!("open oplog {}", oplog_path.display()), into_io(&e)))?;
 
         // 3. Stream socket — unlink any stale socket a crash left behind.
-        let socket_path = canonical.join(SOCKET_FILE);
+        let socket_path = sync_dir.join(SOCKET_FILE);
         let _ignored = fs::remove_file(&socket_path);
         let listener = UnixListener::bind(&socket_path)
             .map_err(|e| Error::io(format!("bind socket {}", socket_path.display()), e))?;
@@ -182,7 +228,9 @@ impl Boot {
         let cap_token = mint_cap_token()?;
         let boot_id = mint_boot_id()?;
 
-        // 5. Registry record, written last and atomically.
+        // 5. Registry record, written last and atomically. It advertises every
+        //    artifact's absolute path (all now under the sync dir), so the
+        //    orchestrator follows automatically with no by-name reconstruction.
         let entry = Entry {
             schema_version: 1,
             id,
@@ -194,7 +242,8 @@ impl Boot {
             binary_version: env!("CARGO_PKG_VERSION").to_owned(),
             socket_path: socket_path.to_string_lossy().into_owned(),
             oplog_path: oplog_path.to_string_lossy().into_owned(),
-            heartbeat_path: canonical.join(HEARTBEAT_FILE).to_string_lossy().into_owned(),
+            heartbeat_path: sync_dir.join(HEARTBEAT_FILE).to_string_lossy().into_owned(),
+            tee_socket_path: sync_dir.join(TEE_SOCKET).to_string_lossy().into_owned(),
             cap_token,
             started_at_ms: now_ms(),
             status: AgentStatus::Starting,
@@ -292,149 +341,4 @@ fn now_ms() -> u64 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    /// Boot into temp folders so tests never touch the real home or cwd.
-    fn boot(folder: &Path, agents: &Path) -> BootResult<Boot> {
-        Boot::start_in(folder, agents, "test-model")
-    }
-
-    #[test]
-    fn boot_acquires_all_resources() {
-        let folder = tempdir().expect("folder");
-        let agents = tempdir().expect("agents");
-        let booted = boot(folder.path(), agents.path()).expect("boot");
-
-        // Registry record exists, 0600, and round-trips.
-        let registry = registry::path(agents.path(), booted.id());
-        assert!(registry.exists(), "registry record written");
-
-        // Socket bound, oplog dir created.
-        assert!(folder.path().join(SOCKET_FILE).exists(), "socket bound");
-        assert!(folder.path().join(OPLOG_DIR).exists(), "oplog dir created");
-
-        // The advertised paths are inside the canonical folder.
-        assert!(booted.entry().oplog_path.ends_with(OPLOG_DIR));
-        assert_eq!(booted.entry().protocol_version, PROTOCOL_VERSION);
-        assert_eq!(booted.cap_token().len(), 64, "256-bit token");
-    }
-
-    #[test]
-    fn second_boot_same_folder_refuses() {
-        let folder = tempdir().expect("folder");
-        let agents = tempdir().expect("agents");
-        let _first = boot(folder.path(), agents.path()).expect("first boot");
-
-        let second = boot(folder.path(), agents.path());
-        assert!(
-            matches!(second, Err(Error::AlreadyRunning { .. })),
-            "a second instance in the same folder must be refused, got {second:?}",
-        );
-    }
-
-    #[test]
-    fn boot_releases_lock_on_drop() {
-        let folder = tempdir().expect("folder");
-        let agents = tempdir().expect("agents");
-        {
-            let _first = boot(folder.path(), agents.path()).expect("first boot");
-        } // dropped here → lock released, registry + socket removed.
-
-        // A fresh boot in the same folder now succeeds.
-        let again = boot(folder.path(), agents.path());
-        assert!(again.is_ok(), "lock must be released on drop, got {again:?}");
-    }
-
-    #[test]
-    fn drop_keeps_registry_record() {
-        let folder = tempdir().expect("folder");
-        let agents = tempdir().expect("agents");
-        let registry;
-        {
-            let booted = boot(folder.path(), agents.path()).expect("boot");
-            registry = registry::path(agents.path(), booted.id());
-            assert!(registry.exists());
-        }
-        assert!(registry.exists(), "registry record must survive graceful drop (agent shows as Disconnected)");
-    }
-
-    #[test]
-    fn stale_socket_is_replaced() {
-        let folder = tempdir().expect("folder");
-        let agents = tempdir().expect("agents");
-        // Simulate a crash leaving a stale socket file.
-        fs::create_dir_all(folder.path()).expect("mkdir");
-        fs::write(folder.path().join(SOCKET_FILE), b"stale").expect("stale socket");
-
-        let booted = boot(folder.path(), agents.path());
-        assert!(booted.is_ok(), "a stale socket must be unlinked and rebound, got {booted:?}");
-    }
-
-    #[test]
-    fn try_start_fails_fast_when_locked_then_recovers_when_freed() {
-        use std::time::Instant;
-
-        let folder = tempdir().expect("folder");
-        let agents = tempdir().expect("agents");
-
-        // A patient boot holds the lock.
-        let first = boot(folder.path(), agents.path()).expect("first boot");
-
-        // A fail-fast `try_start` against the same folder must refuse
-        // *immediately* (no ~2s retry wait) with `AlreadyRunning` — this is the
-        // background recovery path that must never stall the main loop.
-        let started = Instant::now();
-        let contended = Boot::start_inner(folder.path(), agents.path(), "test-model", 0);
-        let elapsed = started.elapsed();
-        assert!(
-            matches!(contended, Err(Error::AlreadyRunning { .. })),
-            "a contended fail-fast attempt must refuse, got {contended:?}",
-        );
-        assert!(
-            elapsed < lock::LOCK_RETRY_BACKOFF,
-            "fail-fast must return well under one backoff ({elapsed:?}), not sleep out the retry window",
-        );
-
-        // Once the holder releases the lock, the next fail-fast attempt wins —
-        // modelling the bridge recovering mid-session after a dying predecessor
-        // finally frees the lock.
-        drop(first);
-        let recovered = Boot::start_inner(folder.path(), agents.path(), "test-model", 0);
-        assert!(recovered.is_ok(), "fail-fast must succeed once the lock is free, got {recovered:?}");
-    }
-
-    /// Read every cleanly-decoded oplog entry across all segments in `dir`.
-    fn read_all_entries(dir: &Path) -> Vec<cp_wire::types::oplog::OpEntry> {
-        let mut out = Vec::new();
-        for idx in cp_oplog::segment::indices(dir).unwrap_or_default() {
-            if let Ok(scan) = cp_oplog::segment::read(&cp_oplog::segment::path(dir, idx)) {
-                out.extend(scan.entries);
-            }
-        }
-        out
-    }
-
-    #[test]
-    fn lifecycle_running_on_boot_and_stopping_on_drop() {
-        let folder = tempdir().expect("folder");
-        let agents = tempdir().expect("agents");
-        let oplog_dir = fs::canonicalize(folder.path()).expect("canon").join(OPLOG_DIR);
-
-        // Boot emits Lifecycle::Running; dropping it emits Lifecycle::Stopping.
-        // The drop joins the oplog commit thread, draining + fsyncing both
-        // records before it returns, so reading after the drop is race-free.
-        let booted = boot(folder.path(), agents.path()).expect("boot");
-        drop(booted);
-
-        let entries = read_all_entries(&oplog_dir);
-        let has_running =
-            entries.iter().any(|e| matches!(e.kind, OpEntryKind::Lifecycle { state: LifecycleState::Running }));
-        let has_stopping =
-            entries.iter().any(|e| matches!(e.kind, OpEntryKind::Lifecycle { state: LifecycleState::Stopping }));
-
-        assert!(has_running, "Lifecycle::Running must be journaled at boot");
-        assert!(has_stopping, "Lifecycle::Stopping must be journaled on graceful drop");
-    }
-}
+mod tests;

--- a/crates/cp-mod-bridge/src/boot/tests.rs
+++ b/crates/cp-mod-bridge/src/boot/tests.rs
@@ -1,0 +1,172 @@
+//! Unit tests for [`Boot`](super::Boot) — split into this sibling file to keep
+//! `boot/mod.rs` within the 500-line budget. A child `#[cfg(test)]` module can
+//! reach its parent's private items (`start_inner`, `BootDirs`, the file-name
+//! constants) through `use super::*`.
+
+use super::*;
+use tempfile::tempdir;
+
+/// Boot into temp folders so tests never touch the real home or cwd.
+fn boot(folder: &Path, agents: &Path) -> BootResult<Boot> {
+    Boot::start_in(folder, agents, "test-model")
+}
+
+/// The per-agent sync dir `start_in` derives for `agents` + `id` (the `sync`
+/// sibling of the agents dir — mirrors production's `~/.context-pilot/{agents,sync}`).
+fn sync_dir_for(agents: &Path, id: &str) -> PathBuf {
+    agents.parent().map_or_else(|| agents.join("sync"), |parent| parent.join("sync")).join(id)
+}
+
+#[test]
+fn boot_acquires_all_resources() {
+    let folder = tempdir().expect("folder");
+    let agents = tempdir().expect("agents");
+    let booted = boot(folder.path(), agents.path()).expect("boot");
+    assert_boot_disk(&booted, folder.path(), agents.path());
+    assert_boot_entry(&booted);
+}
+
+/// Assert the on-disk artifacts land under the SYNC dir (T713), not the realm
+/// folder — split from the advertised-path checks to stay under the
+/// cognitive-complexity cap.
+fn assert_boot_disk(booted: &Boot, folder: &Path, agents: &Path) {
+    assert!(registry::path(agents, booted.id()).exists(), "registry record written");
+    let sync_dir = sync_dir_for(agents, booted.id());
+    assert!(sync_dir.join(SOCKET_FILE).exists(), "socket bound under sync dir");
+    assert!(sync_dir.join(OPLOG_DIR).exists(), "oplog dir created under sync dir");
+    assert!(!folder.join(SOCKET_FILE).exists(), "realm folder stays clean");
+}
+
+/// Assert the advertised registry paths point inside the sync dir + the minted
+/// secrets are the expected width.
+fn assert_boot_entry(booted: &Boot) {
+    assert!(booted.entry().oplog_path.ends_with(OPLOG_DIR));
+    assert!(booted.entry().tee_socket_path.ends_with(TEE_SOCKET));
+    assert_eq!(booted.entry().protocol_version, PROTOCOL_VERSION);
+    assert_eq!(booted.cap_token().len(), 64, "256-bit token");
+}
+
+#[test]
+fn second_boot_same_folder_refuses() {
+    let folder = tempdir().expect("folder");
+    let agents = tempdir().expect("agents");
+    let _first = boot(folder.path(), agents.path()).expect("first boot");
+
+    let second = boot(folder.path(), agents.path());
+    assert!(
+        matches!(second, Err(Error::AlreadyRunning { .. })),
+        "a second instance in the same folder must be refused, got {second:?}",
+    );
+}
+
+#[test]
+fn boot_releases_lock_on_drop() {
+    let folder = tempdir().expect("folder");
+    let agents = tempdir().expect("agents");
+    {
+        let _first = boot(folder.path(), agents.path()).expect("first boot");
+    } // dropped here → lock released, registry + socket removed.
+
+    // A fresh boot in the same folder now succeeds.
+    let again = boot(folder.path(), agents.path());
+    assert!(again.is_ok(), "lock must be released on drop, got {again:?}");
+}
+
+#[test]
+fn drop_keeps_registry_record() {
+    let folder = tempdir().expect("folder");
+    let agents = tempdir().expect("agents");
+    let registry;
+    {
+        let booted = boot(folder.path(), agents.path()).expect("boot");
+        registry = registry::path(agents.path(), booted.id());
+        assert!(registry.exists());
+    }
+    assert!(registry.exists(), "registry record must survive graceful drop (agent shows as Disconnected)");
+}
+
+#[test]
+fn stale_socket_is_replaced() {
+    let folder = tempdir().expect("folder");
+    let agents = tempdir().expect("agents");
+    // Simulate a crash leaving a stale socket file at the bind path — which is
+    // now under the per-agent sync dir (T713), not the realm folder.
+    fs::create_dir_all(folder.path()).expect("mkdir");
+    let canonical = fs::canonicalize(folder.path()).expect("canon");
+    let id = folder_id(&canonical.to_string_lossy());
+    let sync_dir = sync_dir_for(agents.path(), &id);
+    fs::create_dir_all(&sync_dir).expect("mkdir sync");
+    fs::write(sync_dir.join(SOCKET_FILE), b"stale").expect("stale socket");
+
+    let booted = boot(folder.path(), agents.path());
+    assert!(booted.is_ok(), "a stale socket must be unlinked and rebound, got {booted:?}");
+}
+
+#[test]
+fn try_start_fails_fast_when_locked_then_recovers_when_freed() {
+    use std::time::Instant;
+
+    let folder = tempdir().expect("folder");
+    let agents = tempdir().expect("agents");
+
+    // A patient boot holds the lock.
+    let first = boot(folder.path(), agents.path()).expect("first boot");
+
+    // A fail-fast attempt against the same folder must refuse *immediately* (no
+    // ~2s retry wait) with `AlreadyRunning` — the background recovery path that
+    // must never stall the main loop.
+    let started = Instant::now();
+    let sync_root = agents.path().parent().map_or_else(|| agents.path().join("sync"), |p| p.join("sync"));
+    let dirs = BootDirs { agents_dir: agents.path(), sync_root: &sync_root };
+    let contended = Boot::start_inner(folder.path(), dirs, "test-model", 0);
+    let elapsed = started.elapsed();
+    assert!(
+        matches!(contended, Err(Error::AlreadyRunning { .. })),
+        "a contended fail-fast attempt must refuse, got {contended:?}",
+    );
+    assert!(
+        elapsed < lock::LOCK_RETRY_BACKOFF,
+        "fail-fast must return well under one backoff ({elapsed:?}), not sleep out the retry window",
+    );
+
+    // Once the holder releases the lock, the next fail-fast attempt wins —
+    // modelling the bridge recovering mid-session after a dying predecessor
+    // finally frees the lock.
+    drop(first);
+    let recovered = Boot::start_inner(folder.path(), dirs, "test-model", 0);
+    assert!(recovered.is_ok(), "fail-fast must succeed once the lock is free, got {recovered:?}");
+}
+
+/// Read every cleanly-decoded oplog entry across all segments in `dir`.
+fn read_all_entries(dir: &Path) -> Vec<cp_wire::types::oplog::OpEntry> {
+    let mut out = Vec::new();
+    for idx in cp_oplog::segment::indices(dir).unwrap_or_default() {
+        if let Ok(scan) = cp_oplog::segment::read(&cp_oplog::segment::path(dir, idx)) {
+            out.extend(scan.entries);
+        }
+    }
+    out
+}
+
+#[test]
+fn lifecycle_running_on_boot_and_stopping_on_drop() {
+    let folder = tempdir().expect("folder");
+    let agents = tempdir().expect("agents");
+    let canonical = fs::canonicalize(folder.path()).expect("canon");
+    let oplog_dir = sync_dir_for(agents.path(), &folder_id(&canonical.to_string_lossy())).join(OPLOG_DIR);
+
+    // Boot emits Lifecycle::Running; dropping it emits Lifecycle::Stopping. The
+    // drop joins the oplog commit thread, draining + fsyncing both records
+    // before it returns, so reading after the drop is race-free.
+    let booted = boot(folder.path(), agents.path()).expect("boot");
+    drop(booted);
+
+    let entries = read_all_entries(&oplog_dir);
+    let has_running =
+        entries.iter().any(|e| matches!(e.kind, OpEntryKind::Lifecycle { state: LifecycleState::Running }));
+    let has_stopping =
+        entries.iter().any(|e| matches!(e.kind, OpEntryKind::Lifecycle { state: LifecycleState::Stopping }));
+
+    assert!(has_running, "Lifecycle::Running must be journaled at boot");
+    assert!(has_stopping, "Lifecycle::Stopping must be journaled on graceful drop");
+}

--- a/crates/cp-mod-bridge/src/register/registry.rs
+++ b/crates/cp-mod-bridge/src/register/registry.rs
@@ -39,6 +39,24 @@ pub fn default_agents_dir() -> BootResult<PathBuf> {
     Ok(PathBuf::from(home).join(".context-pilot").join("agents"))
 }
 
+/// The default sync-plane root under the user's home: `~/.context-pilot/sync`
+/// (T713).
+///
+/// Each agent's per-realm runtime artifacts (lock, oplog, sockets,
+/// heartbeat) live under `<sync_root>/<id>/` — a global, per-agent-namespaced
+/// location that keeps the user's realm folder clean and bounds the Unix-socket
+/// path length regardless of realm depth. Sibling of [`default_agents_dir`],
+/// so discovery record and sync plane sit next to each other.
+///
+/// # Errors
+///
+/// Returns [`Error::Io`] if `$HOME` is unset.
+pub fn default_sync_root() -> BootResult<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .ok_or_else(|| Error::io("resolve sync root", std::io::Error::other("$HOME is not set")))?;
+    Ok(PathBuf::from(home).join(".context-pilot").join("sync"))
+}
+
 /// The path of the registry file for agent `id` inside `agents_dir`.
 #[must_use]
 pub fn path(agents_dir: &Path, id: &str) -> PathBuf {
@@ -118,6 +136,7 @@ mod tests {
             socket_path: "/proj/.context-pilot/stream.sock".to_owned(),
             oplog_path: "/proj/.context-pilot/oplog".to_owned(),
             heartbeat_path: "/proj/.context-pilot/heartbeat".to_owned(),
+            tee_socket_path: "/proj/.context-pilot/tee.sock".to_owned(),
             cap_token: "secret".to_owned(),
             started_at_ms: 0,
             status: AgentStatus::Starting,

--- a/crates/cp-orchestrator/src/registry/liveness.rs
+++ b/crates/cp-orchestrator/src/registry/liveness.rs
@@ -124,6 +124,7 @@ mod tests {
             socket_path: "/tmp/agent/stream.sock".to_owned(),
             oplog_path: "/tmp/agent/oplog".to_owned(),
             heartbeat_path: Path::new("/unused").to_string_lossy().into_owned(),
+            tee_socket_path: "/tmp/agent/tee.sock".to_owned(),
             cap_token: "tok".to_owned(),
             started_at_ms: 0,
             status: AgentStatus::Running,

--- a/crates/cp-orchestrator/src/registry/mod.rs
+++ b/crates/cp-orchestrator/src/registry/mod.rs
@@ -57,6 +57,15 @@ const TMP_SUFFIX: &str = ".tmp";
 /// so only genuine crash-orphans are ever collected.
 pub const DEFAULT_TMP_GRACE: Duration = Duration::from_mins(1);
 
+/// Default grace before an orphaned per-agent sync dir is reaped (T713).
+///
+/// A `~/.context-pilot/sync/<id>/` dir whose `<id>` no longer has any registry
+/// record belongs to a deleted realm. The 7-day grace is deliberately generous:
+/// the sync dir holds the agent's durable oplog, so an over-eager reap would
+/// destroy history if a realm's record were ever transiently missing. Only a
+/// dir untouched for a full week AND with no registry record is collected.
+pub const DEFAULT_SYNC_ORPHAN_GRACE: Duration = Duration::from_hours(168); // 7 days
+
 /// A change in the fleet observed between two [`scan`](FleetScanner::scan)es.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
@@ -236,6 +245,51 @@ impl FleetScanner {
         }
         Ok(removed)
     }
+
+    /// Delete per-agent sync dirs under `sync_root` whose id has no current
+    /// registry record and which are older than `grace`, returning how many were
+    /// removed (T713 — orphans left behind by deleted realms).
+    ///
+    /// A subdirectory is collected only when BOTH hold: its name is NOT a
+    /// currently-known agent id (a realm merely stale-but-registered keeps its
+    /// record, so its dir is preserved for recovery), and it has been untouched
+    /// for longer than `grace`. Because the sync dir holds the agent's durable
+    /// oplog, the guard is deliberately conservative — use
+    /// [`DEFAULT_SYNC_ORPHAN_GRACE`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`io::Error`] if `sync_root` cannot be listed or a removal fails;
+    /// a missing `sync_root` yields `Ok(0)`. A dir whose age cannot be read is
+    /// conservatively kept.
+    pub fn reap_orphan_sync_dirs(&self, sync_root: &Path, grace: Duration) -> io::Result<u64> {
+        let read_dir = match fs::read_dir(sync_root) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(0),
+            Err(e) => return Err(e),
+        };
+
+        let mut removed: u64 = 0;
+        for raw in read_dir {
+            let entry = raw?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let Some(id) = name.to_str() else { continue };
+            if self.known.contains_key(id) {
+                continue; // a registered agent (live or merely stale) — keep it.
+            }
+            let path = entry.path();
+            if let Some(age) = file_age(&path)
+                && age > grace
+            {
+                fs::remove_dir_all(&path)?;
+                removed = removed.wrapping_add(1);
+            }
+        }
+        Ok(removed)
+    }
 }
 
 /// Read and decode the heartbeat at the record's advertised path, or `None` if
@@ -304,163 +358,4 @@ fn now_ms() -> u64 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    /// A boot id of the exact 32-hex-char width the heartbeat record requires.
-    const BOOT_A: &str = "0123456789abcdef0123456789abcdef";
-
-    /// A pid that cannot name a live process (above any platform's `pid_max`).
-    const DEAD_PID: u32 = 4_000_000_000;
-
-    fn entry(id: &str, pid: u32, hb_path: &Path, status: AgentStatus) -> Entry {
-        Entry {
-            schema_version: 1,
-            id: id.to_owned(),
-            folder: "/tmp/agent".to_owned(),
-            pid,
-            boot_id: BOOT_A.to_owned(),
-            model: "test-model".to_owned(),
-            protocol_version: 1,
-            binary_version: "0.0.0".to_owned(),
-            socket_path: "/tmp/agent/stream.sock".to_owned(),
-            oplog_path: "/tmp/agent/oplog".to_owned(),
-            heartbeat_path: hb_path.to_string_lossy().into_owned(),
-            cap_token: "tok".to_owned(),
-            started_at_ms: 0,
-            status,
-        }
-    }
-
-    fn heartbeat(pid: u32, timestamp_ms: u64) -> Heartbeat {
-        Heartbeat::new(timestamp_ms, 0, pid, BOOT_A.to_owned())
-    }
-
-    /// Write `record` as `<id>.json` into `dir`.
-    fn write_record(dir: &Path, record: &Entry) {
-        let path = dir.join(format!("{}{RECORD_SUFFIX}", record.id));
-        fs::write(path, serde_json::to_vec(record).expect("serialize")).expect("write record");
-    }
-
-    /// Write `hb` to `path` so a verdict can read a real, decodable beat.
-    fn write_heartbeat(path: &Path, hb: &Heartbeat) {
-        fs::write(path, hb.encode().expect("encode")).expect("write heartbeat");
-    }
-
-    /// Assert `events` is a single `Appeared` for `id` and that `id` reads back
-    /// live. A plain call, so hoisting the `matches!` guard out of the test body
-    /// keeps `scan_emits_appeared_then_disappeared` under the cognitive cap.
-    fn assert_appeared_live(reg: &FleetScanner, events: &[Event], id: &str) {
-        assert_eq!(events.len(), 1);
-        assert!(matches!(events.first(), Some(Event::Appeared(e)) if e.id == id));
-        assert_eq!(reg.liveness(id), Some(Liveness::Live), "fresh self-pid agent is live");
-    }
-
-    #[test]
-    fn scan_emits_appeared_then_disappeared() {
-        let dir = tempdir().expect("dir");
-        let me = std::process::id();
-        let hb_path = dir.path().join("hb-a");
-        write_heartbeat(&hb_path, &heartbeat(me, now_ms()));
-        write_record(dir.path(), &entry("a", me, &hb_path, AgentStatus::Running));
-
-        let mut reg = FleetScanner::new(dir.path().to_path_buf());
-        let first = reg.scan().expect("scan");
-        assert_appeared_live(&reg, &first, "a");
-
-        // A second scan with no changes is quiet.
-        assert!(reg.scan().expect("scan").is_empty(), "idempotent scan emits nothing");
-
-        // Remove the record → Disappeared.
-        fs::remove_file(dir.path().join("a.json")).expect("rm");
-        let third = reg.scan().expect("scan");
-        assert_eq!(third, vec![Event::Disappeared("a".to_owned())]);
-        assert!(reg.is_empty());
-    }
-
-    #[test]
-    fn scan_emits_status_change() {
-        let dir = tempdir().expect("dir");
-        let me = std::process::id();
-        let hb_path = dir.path().join("hb-a");
-        write_heartbeat(&hb_path, &heartbeat(me, now_ms()));
-        write_record(dir.path(), &entry("a", me, &hb_path, AgentStatus::Starting));
-
-        let mut reg = FleetScanner::new(dir.path().to_path_buf());
-        let _appeared = reg.scan().expect("scan");
-
-        write_record(dir.path(), &entry("a", me, &hb_path, AgentStatus::Running));
-        let events = reg.scan().expect("scan");
-        assert_eq!(events, vec![Event::StatusChanged("a".to_owned(), AgentStatus::Running)]);
-    }
-
-    #[test]
-    fn scan_emits_stale_on_liveness_loss() {
-        let dir = tempdir().expect("dir");
-        let me = std::process::id();
-        let hb_path = dir.path().join("hb-a");
-        // Start live (fresh beat).
-        write_heartbeat(&hb_path, &heartbeat(me, now_ms()));
-        write_record(dir.path(), &entry("a", me, &hb_path, AgentStatus::Running));
-
-        let mut reg = FleetScanner::new(dir.path().to_path_buf());
-        let _appeared = reg.scan().expect("scan");
-        assert_eq!(reg.liveness("a"), Some(Liveness::Live));
-
-        // Rewrite the heartbeat far in the past → it goes stale.
-        write_heartbeat(&hb_path, &heartbeat(me, 0));
-        let events = reg.scan().expect("scan");
-        assert_eq!(events, vec![Event::Stale("a".to_owned(), Liveness::StaleHeartbeat)]);
-        assert_eq!(reg.liveness("a"), Some(Liveness::StaleHeartbeat));
-    }
-
-    #[test]
-    fn scan_reports_dead_pid_entry_as_stale_not_live() {
-        // The pid-reused / crashed-without-cleanup case: a record whose pid is
-        // not a live process must be reported stale, never live.
-        let dir = tempdir().expect("dir");
-        let hb_path = dir.path().join("hb-a");
-        write_heartbeat(&hb_path, &heartbeat(DEAD_PID, now_ms()));
-        write_record(dir.path(), &entry("a", DEAD_PID, &hb_path, AgentStatus::Running));
-
-        let mut reg = FleetScanner::new(dir.path().to_path_buf());
-        let events = reg.scan().expect("scan");
-        assert!(matches!(events.first(), Some(Event::Appeared(_))));
-        assert_eq!(reg.liveness("a"), Some(Liveness::StalePid), "dead pid \u{2192} stale, not live");
-    }
-
-    #[test]
-    fn scan_skips_unparseable_and_tmp_files() {
-        let dir = tempdir().expect("dir");
-        fs::write(dir.path().join("garbage.json"), b"not json").expect("write");
-        fs::write(dir.path().join("a.json.tmp"), b"{}").expect("write tmp");
-
-        let mut reg = FleetScanner::new(dir.path().to_path_buf());
-        assert!(reg.scan().expect("scan").is_empty(), "garbage + tmp yield no agents");
-    }
-
-    #[test]
-    fn reap_tmp_collects_aged_orphans_only() {
-        let dir = tempdir().expect("dir");
-        let tmp = dir.path().join("x.json.tmp");
-        fs::write(&tmp, b"partial").expect("write tmp");
-
-        let reg = FleetScanner::new(dir.path().to_path_buf());
-        // A long grace protects the just-written tmp (an in-flight write).
-        assert_eq!(reg.reap_tmp(DEFAULT_TMP_GRACE).expect("reap"), 0);
-        assert!(tmp.exists(), "young tmp survives");
-
-        // Zero grace makes any aged file eligible → the orphan is collected.
-        assert_eq!(reg.reap_tmp(Duration::ZERO).expect("reap"), 1);
-        assert!(!tmp.exists(), "aged orphan reaped");
-    }
-
-    #[test]
-    fn empty_or_missing_dir_scans_clean() {
-        let dir = tempdir().expect("dir");
-        let mut reg = FleetScanner::new(dir.path().join("does-not-exist"));
-        assert!(reg.scan().expect("scan").is_empty());
-        assert_eq!(reg.reap_tmp(DEFAULT_TMP_GRACE).expect("reap"), 0);
-    }
-}
+mod tests;

--- a/crates/cp-orchestrator/src/registry/tee_reader.rs
+++ b/crates/cp-orchestrator/src/registry/tee_reader.rs
@@ -55,8 +55,10 @@ const READ_CHUNK: usize = 4096;
 
 /// Tee socket file name inside an agent's folder (mirrors `cp-mod-bridge`'s
 /// `TEE_SOCKET`). Defined here rather than imported to keep the backend's
-/// dependency on the agent crate test-only.
-const TEE_SOCKET: &str = "tee.sock";
+/// dependency on the agent crate test-only. `pub(crate)` so the driver's
+/// fallback path (un-migrated agents with no advertised `tee_socket_path`) can
+/// reconstruct the legacy `<folder>/tee.sock` from the same single name source.
+pub(crate) const TEE_SOCKET: &str = "tee.sock";
 
 /// The backend-side reader of one agent's live stream socket.
 ///
@@ -72,15 +74,17 @@ pub struct TeeReader {
 }
 
 impl TeeReader {
-    /// Spawn a reader for the agent at `folder`, republishing its stream frames
-    /// into `backend`'s [`StreamHub`](crate::services::stream_hub::StreamHub) under
-    /// `agent_id`.
+    /// Spawn a reader for the agent whose live-stream socket is at `tee_path`,
+    /// republishing its stream frames into `backend`'s
+    /// [`StreamHub`](crate::services::stream_hub::StreamHub) under `agent_id`.
     ///
-    /// The reader connects to `<folder>/tee.sock`, retrying while the socket is
-    /// absent, and runs until [`stop`](Self::stop) (or drop) is invoked.
+    /// `tee_path` is the agent's advertised `tee_socket_path` (T713) — resolved
+    /// by the caller, since with the global sync-dir layout the socket is no
+    /// longer under the agent's realm folder. The reader connects to it,
+    /// retrying while the socket is absent, and runs until [`stop`](Self::stop)
+    /// (or drop) is invoked.
     #[must_use]
-    pub fn spawn(agent_id: String, folder: &std::path::Path, backend: Arc<Mutex<Backend>>) -> Self {
-        let tee_path = folder.join(TEE_SOCKET);
+    pub fn spawn(agent_id: String, tee_path: PathBuf, backend: Arc<Mutex<Backend>>) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);
         let handle = thread::spawn(move || read_loop(&agent_id, &tee_path, &backend, &stop_thread));
@@ -259,7 +263,7 @@ mod tests {
         let listener = UnixListener::bind(&tee_path).expect("bind");
 
         let (backend, sub) = backend_with_subscriber("agentX");
-        let reader = TeeReader::spawn("agentX".to_owned(), &folder, Arc::clone(&backend));
+        let reader = TeeReader::spawn("agentX".to_owned(), tee_path, Arc::clone(&backend));
 
         // Accept the reader's connection and write three framed tokens.
         let (mut conn, _addr) = listener.accept().expect("accept");
@@ -295,7 +299,7 @@ mod tests {
         let (backend, sub) = backend_with_subscriber("late");
 
         // Spawn BEFORE the socket exists — the reader must retry, not die.
-        let reader = TeeReader::spawn("late".to_owned(), &folder, Arc::clone(&backend));
+        let reader = TeeReader::spawn("late".to_owned(), folder.join(TEE_SOCKET), Arc::clone(&backend));
         sleep(Duration::from_millis(80));
 
         // Now bind + serve a frame; the reader should connect and deliver it.
@@ -327,7 +331,7 @@ mod tests {
         let listener = UnixListener::bind(&tee_path).expect("bind");
 
         let (backend, sub) = backend_with_subscriber("noisy");
-        let reader = TeeReader::spawn("noisy".to_owned(), &folder, Arc::clone(&backend));
+        let reader = TeeReader::spawn("noisy".to_owned(), tee_path, Arc::clone(&backend));
         let (mut conn, _addr) = listener.accept().expect("accept");
 
         // Garbage bytes that look like a frame header with a CRC mismatch, then

--- a/crates/cp-orchestrator/src/registry/tests.rs
+++ b/crates/cp-orchestrator/src/registry/tests.rs
@@ -1,0 +1,190 @@
+//! Unit tests for [`FleetScanner`](super::FleetScanner), split from `mod.rs`
+//! to keep that file within the 500-line cap (the supervisor/tests.rs precedent).
+
+use super::*;
+use tempfile::tempdir;
+
+/// A boot id of the exact 32-hex-char width the heartbeat record requires.
+const BOOT_A: &str = "0123456789abcdef0123456789abcdef";
+
+/// A pid that cannot name a live process (above any platform's `pid_max`).
+const DEAD_PID: u32 = 4_000_000_000;
+
+fn entry(id: &str, pid: u32, hb_path: &Path, status: AgentStatus) -> Entry {
+    Entry {
+        schema_version: 1,
+        id: id.to_owned(),
+        folder: "/tmp/agent".to_owned(),
+        pid,
+        boot_id: BOOT_A.to_owned(),
+        model: "test-model".to_owned(),
+        protocol_version: 1,
+        binary_version: "0.0.0".to_owned(),
+        socket_path: "/tmp/agent/stream.sock".to_owned(),
+        oplog_path: "/tmp/agent/oplog".to_owned(),
+        heartbeat_path: hb_path.to_string_lossy().into_owned(),
+        tee_socket_path: "/tmp/agent/tee.sock".to_owned(),
+        cap_token: "tok".to_owned(),
+        started_at_ms: 0,
+        status,
+    }
+}
+
+fn heartbeat(pid: u32, timestamp_ms: u64) -> Heartbeat {
+    Heartbeat::new(timestamp_ms, 0, pid, BOOT_A.to_owned())
+}
+
+/// Write `record` as `<id>.json` into `dir`.
+fn write_record(dir: &Path, record: &Entry) {
+    let path = dir.join(format!("{}{RECORD_SUFFIX}", record.id));
+    fs::write(path, serde_json::to_vec(record).expect("serialize")).expect("write record");
+}
+
+/// Write `hb` to `path` so a verdict can read a real, decodable beat.
+fn write_heartbeat(path: &Path, hb: &Heartbeat) {
+    fs::write(path, hb.encode().expect("encode")).expect("write heartbeat");
+}
+
+/// Assert `events` is a single `Appeared` for `id` and that `id` reads back
+/// live. A plain call, so hoisting the `matches!` guard out of the test body
+/// keeps `scan_emits_appeared_then_disappeared` under the cognitive cap.
+fn assert_appeared_live(reg: &FleetScanner, events: &[Event], id: &str) {
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events.first(), Some(Event::Appeared(e)) if e.id == id));
+    assert_eq!(reg.liveness(id), Some(Liveness::Live), "fresh self-pid agent is live");
+}
+
+#[test]
+fn scan_emits_appeared_then_disappeared() {
+    let dir = tempdir().expect("dir");
+    let me = std::process::id();
+    let hb_path = dir.path().join("hb-a");
+    write_heartbeat(&hb_path, &heartbeat(me, now_ms()));
+    write_record(dir.path(), &entry("a", me, &hb_path, AgentStatus::Running));
+
+    let mut reg = FleetScanner::new(dir.path().to_path_buf());
+    let first = reg.scan().expect("scan");
+    assert_appeared_live(&reg, &first, "a");
+
+    // A second scan with no changes is quiet.
+    assert!(reg.scan().expect("scan").is_empty(), "idempotent scan emits nothing");
+
+    // Remove the record → Disappeared.
+    fs::remove_file(dir.path().join("a.json")).expect("rm");
+    let third = reg.scan().expect("scan");
+    assert_eq!(third, vec![Event::Disappeared("a".to_owned())]);
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn scan_emits_status_change() {
+    let dir = tempdir().expect("dir");
+    let me = std::process::id();
+    let hb_path = dir.path().join("hb-a");
+    write_heartbeat(&hb_path, &heartbeat(me, now_ms()));
+    write_record(dir.path(), &entry("a", me, &hb_path, AgentStatus::Starting));
+
+    let mut reg = FleetScanner::new(dir.path().to_path_buf());
+    let _appeared = reg.scan().expect("scan");
+
+    write_record(dir.path(), &entry("a", me, &hb_path, AgentStatus::Running));
+    let events = reg.scan().expect("scan");
+    assert_eq!(events, vec![Event::StatusChanged("a".to_owned(), AgentStatus::Running)]);
+}
+
+#[test]
+fn scan_emits_stale_on_liveness_loss() {
+    let dir = tempdir().expect("dir");
+    let me = std::process::id();
+    let hb_path = dir.path().join("hb-a");
+    // Start live (fresh beat).
+    write_heartbeat(&hb_path, &heartbeat(me, now_ms()));
+    write_record(dir.path(), &entry("a", me, &hb_path, AgentStatus::Running));
+
+    let mut reg = FleetScanner::new(dir.path().to_path_buf());
+    let _appeared = reg.scan().expect("scan");
+    assert_eq!(reg.liveness("a"), Some(Liveness::Live));
+
+    // Rewrite the heartbeat far in the past → it goes stale.
+    write_heartbeat(&hb_path, &heartbeat(me, 0));
+    let events = reg.scan().expect("scan");
+    assert_eq!(events, vec![Event::Stale("a".to_owned(), Liveness::StaleHeartbeat)]);
+    assert_eq!(reg.liveness("a"), Some(Liveness::StaleHeartbeat));
+}
+
+#[test]
+fn scan_reports_dead_pid_entry_as_stale_not_live() {
+    // The pid-reused / crashed-without-cleanup case: a record whose pid is
+    // not a live process must be reported stale, never live.
+    let dir = tempdir().expect("dir");
+    let hb_path = dir.path().join("hb-a");
+    write_heartbeat(&hb_path, &heartbeat(DEAD_PID, now_ms()));
+    write_record(dir.path(), &entry("a", DEAD_PID, &hb_path, AgentStatus::Running));
+
+    let mut reg = FleetScanner::new(dir.path().to_path_buf());
+    let events = reg.scan().expect("scan");
+    assert!(matches!(events.first(), Some(Event::Appeared(_))));
+    assert_eq!(reg.liveness("a"), Some(Liveness::StalePid), "dead pid \u{2192} stale, not live");
+}
+
+#[test]
+fn scan_skips_unparseable_and_tmp_files() {
+    let dir = tempdir().expect("dir");
+    fs::write(dir.path().join("garbage.json"), b"not json").expect("write");
+    fs::write(dir.path().join("a.json.tmp"), b"{}").expect("write tmp");
+
+    let mut reg = FleetScanner::new(dir.path().to_path_buf());
+    assert!(reg.scan().expect("scan").is_empty(), "garbage + tmp yield no agents");
+}
+
+#[test]
+fn reap_tmp_collects_aged_orphans_only() {
+    let dir = tempdir().expect("dir");
+    let tmp = dir.path().join("x.json.tmp");
+    fs::write(&tmp, b"partial").expect("write tmp");
+
+    let reg = FleetScanner::new(dir.path().to_path_buf());
+    // A long grace protects the just-written tmp (an in-flight write).
+    assert_eq!(reg.reap_tmp(DEFAULT_TMP_GRACE).expect("reap"), 0);
+    assert!(tmp.exists(), "young tmp survives");
+
+    // Zero grace makes any aged file eligible → the orphan is collected.
+    assert_eq!(reg.reap_tmp(Duration::ZERO).expect("reap"), 1);
+    assert!(!tmp.exists(), "aged orphan reaped");
+}
+
+#[test]
+fn reap_orphan_sync_dirs_collects_only_unregistered_aged_dirs() {
+    // Register one live agent "a"; its sync dir must be preserved.
+    let agents = tempdir().expect("agents");
+    let me = std::process::id();
+    let hb_path = agents.path().join("hb-a");
+    write_heartbeat(&hb_path, &heartbeat(me, now_ms()));
+    write_record(agents.path(), &entry("a", me, &hb_path, AgentStatus::Running));
+    let mut reg = FleetScanner::new(agents.path().to_path_buf());
+    let _appeared = reg.scan().expect("scan");
+
+    // A sibling sync root with the registered agent's dir + an orphan.
+    let sync_root = agents.path().join("..").join("sync-test-root");
+    fs::create_dir_all(sync_root.join("a")).expect("mkdir a");
+    fs::create_dir_all(sync_root.join("ghost")).expect("mkdir ghost");
+
+    // A long grace protects everything (both dirs just created).
+    assert_eq!(reg.reap_orphan_sync_dirs(&sync_root, DEFAULT_SYNC_ORPHAN_GRACE).expect("reap"), 0);
+    assert!(sync_root.join("a").exists() && sync_root.join("ghost").exists(), "young dirs survive");
+
+    // Zero grace: only the UNREGISTERED dir is collected; "a" is kept.
+    assert_eq!(reg.reap_orphan_sync_dirs(&sync_root, Duration::ZERO).expect("reap"), 1);
+    assert!(sync_root.join("a").exists(), "a registered agent's sync dir is preserved");
+    assert!(!sync_root.join("ghost").exists(), "an orphan sync dir past grace is reaped");
+
+    let _cleanup = fs::remove_dir_all(&sync_root);
+}
+
+#[test]
+fn empty_or_missing_dir_scans_clean() {
+    let dir = tempdir().expect("dir");
+    let mut reg = FleetScanner::new(dir.path().join("does-not-exist"));
+    assert!(reg.scan().expect("scan").is_empty());
+    assert_eq!(reg.reap_tmp(DEFAULT_TMP_GRACE).expect("reap"), 0);
+}

--- a/crates/cp-orchestrator/src/runtime/driver.rs
+++ b/crates/cp-orchestrator/src/runtime/driver.rs
@@ -64,6 +64,7 @@ pub(super) fn driver_loop(
     interval: Duration,
     mut backup_scheduler: Option<BackupScheduler>,
 ) -> ! {
+    let sync_root = agents_dir.parent().map(|p| p.join("sync"));
     let mut registry = FleetScanner::new(agents_dir);
     let mut ds = DriverState::default();
 
@@ -91,6 +92,17 @@ pub(super) fn driver_loop(
 
         // 3. Reap stale *.tmp registry writes (crash-orphans).
         let _reaped = registry.reap_tmp(crate::registry::DEFAULT_TMP_GRACE);
+
+        // 3b. Reap orphaned per-agent sync dirs left behind by DELETED realms
+        //     (T713). The sync plane lives at `~/.context-pilot/sync/<id>/` —
+        //     the sibling of the agents dir. A realm's deletion removes its
+        //     registry record but NOT its global sync dir, so a `sync/<id>/`
+        //     whose id no longer has any registry record is an orphan; it is
+        //     reaped once older than the 7-day grace (an agent merely stale but
+        //     still registered keeps its dir, so a recovery is never broken).
+        if let Some(root) = sync_root.as_ref() {
+            let _orphans = registry.reap_orphan_sync_dirs(root, crate::registry::DEFAULT_SYNC_ORPHAN_GRACE);
+        }
 
         // 4. Auth database backup (NFR-19/20) — rolling + daily snapshots.
         if let Some(scheduler) = backup_scheduler.as_mut()
@@ -157,14 +169,32 @@ fn handle_appeared(entry: &Entry, backend: &Arc<Mutex<Backend>>, ds: &mut Driver
     drop(ds.tailers.insert(entry.id.clone(), Tailer::new(oplog_dir)));
     let folder = PathBuf::from(&entry.folder);
     // Spawn the live stream reader for this agent's tee socket so its token
-    // frames fan out through the hub to SSE subscribers.
-    let reader = TeeReader::spawn(entry.id.clone(), &folder, Arc::clone(backend));
+    // frames fan out through the hub to SSE subscribers. The socket path is the
+    // agent's advertised `tee_socket_path` (T713 global sync dir); an older
+    // agent that predates the field advertises `""`, so we fall back to the
+    // legacy `<folder>/tee.sock` reconstruction and still serve it.
+    let reader = TeeReader::spawn(entry.id.clone(), resolve_tee_path(entry), Arc::clone(backend));
     if let Some(old) = ds.tee_readers.insert(entry.id.clone(), reader) {
         old.stop();
     }
     drop(ds.agent_folders.insert(entry.id.clone(), folder));
     if let Ok(mut b) = backend.lock() {
         let _: Option<crate::liveness::Liveness> = b.liveness.insert(entry.id.clone(), crate::liveness::Liveness::Live);
+    }
+}
+
+/// Resolve an agent's live-stream tee socket path.
+///
+/// Prefers the advertised `tee_socket_path` (T713 — the agent puts its tee
+/// socket under the global `~/.context-pilot/sync/<id>/`, so it can no longer be
+/// reconstructed from `folder`). An agent that predates the field advertises an
+/// empty string; for it we fall back to the legacy `<folder>/tee.sock`, so an
+/// old, un-migrated agent still gets its stream plane read.
+fn resolve_tee_path(entry: &Entry) -> PathBuf {
+    if entry.tee_socket_path.is_empty() {
+        PathBuf::from(&entry.folder).join(crate::registry::tee_reader::TEE_SOCKET)
+    } else {
+        PathBuf::from(&entry.tee_socket_path)
     }
 }
 

--- a/crates/cp-orchestrator/src/supervisor/tests.rs
+++ b/crates/cp-orchestrator/src/supervisor/tests.rs
@@ -116,6 +116,7 @@ fn adopt_and_detect_vanish() {
         socket_path: String::new(),
         oplog_path: String::new(),
         heartbeat_path: String::new(),
+        tee_socket_path: String::new(),
         cap_token: String::new(),
         started_at_ms: 0,
         status: cp_wire::types::registry::AgentStatus::Running,

--- a/crates/cp-orchestrator/tests/end_to_end.rs
+++ b/crates/cp-orchestrator/tests/end_to_end.rs
@@ -99,6 +99,7 @@ mod tests {
             socket_path: dir.join("stream.sock").to_string_lossy().into_owned(),
             oplog_path: dir.join("oplog").to_string_lossy().into_owned(),
             heartbeat_path: dir.join("hb").to_string_lossy().into_owned(),
+            tee_socket_path: dir.join("tee.sock").to_string_lossy().into_owned(),
             cap_token: cap_token.to_owned(),
             started_at_ms: 0,
             status: AgentStatus::Running,

--- a/crates/cp-orchestrator/tests/registry_channel.rs
+++ b/crates/cp-orchestrator/tests/registry_channel.rs
@@ -111,6 +111,7 @@ mod tests {
             socket_path: socket_path.to_string_lossy().into_owned(),
             oplog_path: oplog_path.to_string_lossy().into_owned(),
             heartbeat_path: hb_path.to_string_lossy().into_owned(),
+            tee_socket_path: String::new(),
             cap_token: "tok".to_owned(),
             started_at_ms: 0,
             status: AgentStatus::Running,

--- a/crates/cp-orchestrator/tests/supervisor_lifecycle.rs
+++ b/crates/cp-orchestrator/tests/supervisor_lifecycle.rs
@@ -92,6 +92,7 @@ mod tests {
             socket_path: String::new(),
             oplog_path: String::new(),
             heartbeat_path: String::new(),
+            tee_socket_path: String::new(),
             cap_token: String::new(),
             started_at_ms: 0,
             status: AgentStatus::Running,

--- a/crates/cp-orchestrator/tests/transport_http.rs
+++ b/crates/cp-orchestrator/tests/transport_http.rs
@@ -80,6 +80,7 @@ mod tests {
             socket_path: oplog_dir.join("stream.sock").to_string_lossy().into_owned(),
             oplog_path: oplog_dir.to_string_lossy().into_owned(),
             heartbeat_path: oplog_dir.join("hb").to_string_lossy().into_owned(),
+            tee_socket_path: oplog_dir.join("tee.sock").to_string_lossy().into_owned(),
             cap_token: "cap-token".to_owned(),
             started_at_ms: 0,
             status: AgentStatus::Running,

--- a/crates/cp-wire/src/types/registry.rs
+++ b/crates/cp-wire/src/types/registry.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[expect(
     clippy::exhaustive_structs,
-    reason = "registry-record contract: Entry is a 14-field agent discovery record written cross-crate by the bridge boot path and read field-by-field by the backend; a constructor would take 13 positional arguments (tripping too_many_arguments) with no natural grouping, so #[non_exhaustive] is impossible and the exhaustive literal is the honest shape"
+    reason = "registry-record contract: Entry is a 15-field agent discovery record written cross-crate by the bridge boot path and read field-by-field by the backend; a constructor would take 14 positional arguments (tripping too_many_arguments) with no natural grouping, so #[non_exhaustive] is impossible and the exhaustive literal is the honest shape"
 )]
 pub struct Entry {
     /// Wire-schema revision for this struct.
@@ -47,6 +47,14 @@ pub struct Entry {
 
     /// Path to the agent's heartbeat file.
     pub heartbeat_path: String,
+
+    /// Path to the agent's live-stream tee socket (T713). Advertised as an
+    /// absolute path so the orchestrator no longer reconstructs it by name from
+    /// `folder`. `#[serde(default)]` keeps N-1 compat: an entry written by an
+    /// older agent lacks this field and decodes to `""`, at which point the
+    /// orchestrator falls back to `folder.join("tee.sock")`.
+    #[serde(default)]
+    pub tee_socket_path: String,
 
     /// Bearer capability token for command authn (I9, `0600`).
     pub cap_token: String,
@@ -94,6 +102,7 @@ mod tests {
             socket_path: "/home/user/project/.context-pilot/stream.sock".into(),
             oplog_path: "/home/user/project/.context-pilot/oplog".into(),
             heartbeat_path: "/home/user/project/.context-pilot/heartbeat".into(),
+            tee_socket_path: "/home/user/project/.context-pilot/tee.sock".into(),
             cap_token: "tok-secret-256bit".into(),
             started_at_ms: 1_718_000_000_000,
             status: AgentStatus::Running,
@@ -138,5 +147,9 @@ mod tests {
         }"#;
         let entry: Entry = serde_json::from_str(json).expect("tolerant decode");
         assert_eq!(entry.status, AgentStatus::Running);
+        // An entry written by an older agent (pre-T713) has no `tee_socket_path`;
+        // `#[serde(default)]` must decode it to `""` so the orchestrator falls
+        // back to reconstructing the tee path from `folder`.
+        assert_eq!(entry.tee_socket_path, "");
     }
 }

--- a/docs/design-sync-dir-migration.md
+++ b/docs/design-sync-dir-migration.md
@@ -1,0 +1,268 @@
+# Migration: runtime artifacts → `~/.context-pilot/sync/<agent-id>/`
+
+**Status:** proposal (T713). Exploration + plan only — no code changed yet.
+**Decision (T713):** the sync plane moves to a **global, per-agent-namespaced**
+directory in `$HOME`, not a per-realm subdir. Per-realm is kept below as the
+alternative that was considered.
+
+## 1. Goal
+
+Move the five per-realm *runtime* artifacts out of the realm **root** and into a
+single **global, per-agent** directory, `~/.context-pilot/sync/<agent-id>/`:
+
+| Artifact       | Today (realm root)     | Proposed (global, per-agent)                        |
+| -------------- | ---------------------- | --------------------------------------------------- |
+| `bridge.lock`  | `<realm>/bridge.lock`  | `~/.context-pilot/sync/<id>/bridge.lock`            |
+| `heartbeat`    | `<realm>/heartbeat`    | `~/.context-pilot/sync/<id>/heartbeat`              |
+| `stream.sock`  | `<realm>/stream.sock`  | `~/.context-pilot/sync/<id>/stream.sock`            |
+| `tee.sock`     | `<realm>/tee.sock`     | `~/.context-pilot/sync/<id>/tee.sock`               |
+| `oplog/`       | `<realm>/oplog/`       | `~/.context-pilot/sync/<id>/oplog/`                 |
+
+`<id>` is the agent's stable identifier — the **FNV-1a hash of the canonical
+realm path** (`register::identity::folder_id`), the *same* id the registry
+already uses for `~/.context-pilot/agents/<id>.json`. So the sync plane sits
+right next to the discovery record it belongs to, and is consistent with what is
+*already* global.
+
+### Why per-agent namespacing is mandatory (not a flat shared dir)
+
+One host runs **many** agents (one per realm). A single flat
+`~/.context-pilot/sync/` would collide catastrophically:
+
+- `bridge.lock` would become a whole-**host** gate instead of a per-realm gate —
+  the second agent on the box could never boot. This breaks multi-agent entirely.
+- Two agents cannot share one `oplog/`, one `heartbeat`, or one socket.
+
+So the `<agent-id>/` level is load-bearing, not cosmetic.
+
+### Why global beats per-realm
+
+- ✅ **Eliminates the socket path-length hazard.** `sun_path` caps at ~104 bytes
+  (macOS) / ~108 (Linux). A per-realm `<realm>/.context-pilot/sync/tee.sock`
+  inherits the realm's (possibly deep) absolute path and can overflow. The global
+  path `~/.context-pilot/sync/<16-hex>/tee.sock` (≈ 55 chars for a typical
+  `$HOME`) is **bounded and short regardless of realm depth**. This was the top
+  hazard of the per-realm plan; global retires it.
+- ✅ **The user's project tree stays completely clean** — nothing is written into
+  the realm folder at all.
+- ✅ **One directory to tmpfs-mount / wipe** for the whole host's ephemeral
+  coordination state.
+- ✅ **Consistent with the existing global registry** (`~/.context-pilot/agents/`).
+
+### The costs of global (both addressed below)
+
+- ⚠️ **Orphaned sync dirs** when a realm is deleted (§4e — needs a reaper).
+- ⚠️ **Forces the wire change** (`tee_socket_path`, §3) — the tee socket is no
+  longer under `entry.folder`, so by-name reconstruction is impossible.
+
+`oplog/bodies/` moves for free — it is always derived as `oplog_path.join("bodies")`
+on both sides (`cp-mod-bridge/src/body.rs`, `cp-orchestrator/.../channel.rs`), so
+moving the whole `oplog/` dir keeps the content-addressed body store intact.
+
+## 2. Who owns / reads each path (verified, current state)
+
+All five artifacts today live directly at `entry.folder` (the canonicalized agent
+cwd = realm root).
+
+### Agent side — `crates/cp-mod-bridge` (writer of all five)
+
+| Artifact      | Constant / site                                             |
+| ------------- | ---------------------------------------------------------- |
+| `bridge.lock` | `boot/lock.rs::LOCK_FILE`, `folder.join(LOCK_FILE)` in `acquire_lock` |
+| `oplog/`      | `boot/mod.rs::OPLOG_DIR`, `canonical.join(OPLOG_DIR)`      |
+| `stream.sock` | `boot/mod.rs::SOCKET_FILE`, `canonical.join(SOCKET_FILE)`  |
+| `heartbeat`   | `boot/mod.rs::HEARTBEAT_FILE`, `canonical.join(HEARTBEAT_FILE)` |
+| `tee.sock`    | `boot/activate.rs::TEE_SOCKET`, `Path::new(&entry.folder).join(TEE_SOCKET)` |
+
+The boot sequence (`boot/mod.rs::start_inner`) computes
+`id = folder_id(&canonical)` early (before the lock) and writes the registry
+`Entry` with the **absolute** paths it chose (`socket_path`, `oplog_path`,
+`heartbeat_path`). Because the id is already available before any resource is
+acquired, building `~/.context-pilot/sync/<id>/` at boot needs no new plumbing.
+
+### Orchestrator side — `crates/cp-orchestrator` (reader)
+
+The orchestrator is **almost entirely path-agnostic**: it reads absolute paths
+verbatim from the registry `Entry` and never reconstructs them by name.
+
+| Path             | How the orchestrator gets it                | Path-agnostic? |
+| ---------------- | ------------------------------------------- | -------------- |
+| command socket   | `entry.socket_path` → `registry/channel.rs` connect | ✅ yes |
+| oplog dir        | `entry.oplog_path` → tailer, `metrics.rs`, `runtime/driver.rs`, `stream/upgrade.rs` | ✅ yes |
+| body store       | `Path::new(&entry.oplog_path).join("bodies")` → `channel.rs` | ✅ yes (follows oplog) |
+| heartbeat        | `entry.heartbeat_path` → `registry/liveness.rs`, `registry/mod.rs`, `vitals/mod.rs` | ✅ yes |
+| **tee socket**   | **`PathBuf::from(&entry.folder)` then `TeeReader::spawn` joins `"tee.sock"`** (`runtime/driver.rs:158-161` + `registry/tee_reader.rs::TEE_SOCKET`) | ❌ **NO — reconstructed by name** |
+
+Because `socket_path` / `oplog_path` / `heartbeat_path` are advertised as
+absolute paths, moving them into `~/.context-pilot/sync/<id>/` needs **zero
+orchestrator change and no wire change** — the orchestrator follows automatically.
+
+## 3. The one hard coupling: `tee.sock` → `tee_socket_path` is now MANDATORY
+
+`bridge.lock` is not in the registry at all (agent-internal single-process gate) —
+moving it is agent-only, zero orchestrator coordination.
+
+`stream.sock`, `oplog/`, `heartbeat` are advertised as absolute paths — the agent
+puts them under `sync/<id>/` and the orchestrator follows automatically.
+
+`tee.sock` is the exception: it is advertised **nowhere** yet reconstructed by
+**both** sides from `entry.folder + "tee.sock"`. With the global location the tee
+socket is **no longer under `entry.folder` at all**, so the "Option B" lockstep
+rename that was possible for a per-realm move **is not available** here. The tee
+path *must* become a first-class advertised field:
+
+### Advertise `tee_socket_path` in the registry `Entry` (required)
+
+Add a 15th field `tee_socket_path: String` to `cp-wire`'s `registry::Entry`. The
+agent writes the absolute tee path (like it already does for the other three);
+the orchestrator reads it verbatim and drops the by-name reconstruction. This
+**removes the last name-coupling for good** and makes the migration
+deploy-order-tolerant.
+
+- `cp-wire` is the N-1 compat boundary. `Entry` deserialization is already
+  tolerant of unknown fields (`registry_extra_fields_ignored` test), so an **old
+  orchestrator** reading a **new** entry just ignores `tee_socket_path`. It would
+  then fall back to `entry.folder + "tee.sock"` — which now points at nothing
+  (the agent no longer writes there). Consequence: **an old orchestrator loses
+  the live token-stream plane for a migrated agent** (the durable oplog remains
+  the safety net, so it degrades quietly, not crashes). This makes the rollout
+  order (§6) load-bearing: **ship the orchestrator first.**
+- A **new orchestrator** reading an **old** entry (no field) must fall back to
+  `entry.folder.join("tee.sock")`. Implement `tee_socket_path` handling as
+  "use the field if non-empty, else reconstruct from folder" so a new
+  orchestrator still serves un-migrated agents.
+- `Entry` carries `#[expect(clippy::exhaustive_structs)]`; the field count in the
+  justification comment (currently "14-field") must be updated to 15, and the
+  round-trip + sample-entry tests extended.
+
+## 4. Hazards
+
+### 4a. Unix socket path length — RESOLVED by the global location ✅
+
+This was the top risk of the per-realm plan (deep realm → `bind` `ENAMETOOLONG`
+→ bridge boots OFF). The global path
+`~/.context-pilot/sync/<16-hex-id>/{stream,tee}.sock` has a bounded length that
+does **not** grow with realm depth, so the hazard is retired. (A pathologically
+long `$HOME` is the only residual, and is not realistic; a cheap length preflight
+on bind can still log a clear error rather than a raw errno.)
+
+### 4b. Existing on-disk oplog must be migrated (now possibly cross-device) ⚠️
+
+An existing agent has a populated `<realm>/oplog/` (durable rev history, `seen`
+dedup set, body store). Pointing at the new location without moving it starts a
+**fresh** oplog: command dedup resets, and the message chokepoint could re-emit a
+`MessageCreated` backlog (double bubbles) until memos reseed.
+
+Boot must perform a **one-time move**: if `~/.context-pilot/sync/<id>/oplog/` is
+absent AND the old `<realm>/oplog/` exists, relocate it before opening.
+
+- **`rename` is atomic and cheap only *within one filesystem*.** With the global
+  location the source (realm, possibly on an external/removable drive or a
+  different mount) and the destination (`$HOME`) can be on **different devices** →
+  `rename` fails with `EXDEV`. Boot must therefore implement a **copy + fsync +
+  remove fallback** for the cross-device case (walk the segments + `bodies/`,
+  copy each, fsync, then remove the source). This is more prominent for the
+  global plan than it was for the per-realm plan (where source and dest were
+  always the same fs).
+- Nothing else needs migration: the lock, sockets, and heartbeat are recreated
+  fresh every boot.
+
+### 4c. Directory creation + stale cleanup ordering
+
+Boot must `create_dir_all(~/.context-pilot/sync/<id>)` **before** acquiring the
+lock / binding sockets / opening the oplog. The existing stale-socket unlink
+(`fs::remove_file` before `bind`) must target the new paths. `$HOME` must resolve
+(reuse the same failure path the registry already has when `$HOME` is unset).
+
+### 4d. Deploy trap (M177)
+
+Ship the **orchestrator first** (it must understand `tee_socket_path` before any
+agent starts advertising it — see §3 / §6). After the deploy, verify the live
+stream plane (open a thread, confirm tokens stream) — a broken tee plane is
+silent because the oplog masks it.
+
+### 4e. Orphaned sync dirs — needs a reaper (new, global-only) ⚠️
+
+Per-realm, deleting a realm folder deletes its sync artifacts with it. Global,
+the `~/.context-pilot/sync/<id>/` dir **survives** the realm's deletion and
+accumulates in `$HOME` with nobody to clean it.
+
+Add a **reaper**: during a registry scan, a `sync/<id>/` directory whose `<id>`
+has **no live registry entry** and **no live process** (and is older than a grace
+period) is removed. There is a natural home for this next to the registry's
+existing crash-orphan collector (`reap_tmp` in `registry/mod.rs`). Guard it with a
+grace window so a booting agent that has created its sync dir but not yet written
+its registry record is never reaped mid-boot.
+
+## 5. Exact change set
+
+**`cp-mod-bridge` (agent):**
+- `register/identity.rs` (or `boot/mod.rs`): add a `sync_dir(id)` helper resolving
+  `~/.context-pilot/sync/<id>` (reuse the `$HOME` resolution behind
+  `registry::default_agents_dir` — e.g. a sibling `default_sync_dir(id)` that
+  returns `<home>/.context-pilot/sync/<id>`).
+- `boot/mod.rs::start_inner`: after computing `id`, `create_dir_all(sync_dir)`
+  first; build `OPLOG_DIR`, `SOCKET_FILE`, `HEARTBEAT_FILE` **under `sync_dir`**;
+  add the one-time oplog move with the cross-device copy fallback (§4b). The
+  registry `Entry` then advertises the new absolute paths automatically.
+- `boot/lock.rs`: `acquire_lock` takes/joins the lock under `sync_dir` (pass the
+  sync dir instead of the realm folder).
+- `boot/activate.rs`: `setup_tee` binds `tee.sock` under `sync_dir`; set
+  `entry.tee_socket_path`.
+- Update the module-doc path narration in `boot/mod.rs` + `lib.rs`.
+- Update the affected unit tests (they assert `folder.join("stream.sock")` etc. —
+  they'll now assert under a temp `sync_dir`; the tests already pass an explicit
+  `agents_dir` tempdir, so give them an explicit `sync_dir` tempdir the same way).
+
+**`cp-wire`:**
+- `types/registry.rs`: add `tee_socket_path: String`; update the exhaustive-struct
+  justification (14→15); extend the round-trip + sample-entry tests.
+
+**`cp-orchestrator`:**
+- `runtime/driver.rs` + `registry/tee_reader.rs`: use `entry.tee_socket_path` when
+  non-empty, else fall back to `entry.folder.join("tee.sock")` (serves un-migrated
+  agents). `TeeReader::spawn` takes the full socket path instead of a folder.
+- Add the **orphan reaper** (§4e) near `registry/mod.rs::reap_tmp`.
+- All other consumers (`channel.rs`, `metrics.rs`, `liveness.rs`, `vitals/mod.rs`,
+  `stream/upgrade.rs`) need **no change** — they read absolute paths from the
+  registry.
+
+**Repo hygiene:**
+- `.gitignore`: the realm-root entries for `bridge.lock`, `stream.sock`,
+  `tee.sock`, `heartbeat`, `oplog` become unnecessary (nothing is written into the
+  realm anymore) — they can be removed once the migration ships. `~/.context-pilot`
+  is outside any repo, so no ignore rule is needed for the new location.
+- `crates/cp-mod-tree/src/lib.rs:323` lists `"oplog"` in a tree-filter default —
+  it can be dropped once the oplog no longer lives in the realm.
+
+## 6. Rollout order
+
+1. Ship the **orchestrator** first: it reads `tee_socket_path` when present and
+   falls back to `entry.folder + "tee.sock"` otherwise. It still fully serves old
+   (un-migrated) agents, and is ready for new ones.
+2. Ship the **agent** second: it writes artifacts under
+   `~/.context-pilot/sync/<id>/`, advertises the new absolute paths +
+   `tee_socket_path`, and runs the one-time oplog move.
+3. Verify: registry entry shows `sync/<id>/` paths; heartbeat/liveness green; open
+   a thread and confirm live token streaming (tee plane); confirm command intake
+   (send a message) still connects; confirm the realm folder no longer gains any
+   runtime artifacts.
+
+## 7. Open questions for the user
+
+1. **Oplog migration (§4b):** auto-move the existing `oplog/` on first boot (with
+   the cross-device copy fallback), or accept a fresh oplog on the new path
+   (simpler, but resets dedup/rev history and risks a one-time `MessageCreated`
+   backlog)?
+2. **Reaper grace period (§4e):** what grace window before an entry-less
+   `sync/<id>/` is reaped (e.g. only reap dirs with no registry entry AND
+   untouched for > 24h)?
+
+## Appendix — alternative considered: per-realm `<realm>/.context-pilot/sync/`
+
+The original plan grouped the artifacts under the realm's existing
+`.context-pilot/` directory. It is **self-contained** (deleting the realm deletes
+everything, no reaper needed) and needs **no wire change** if `tee.sock` is moved
+in lockstep on both sides. It was rejected because it **inherits the realm's
+absolute path length** and so risks `bind` `ENAMETOOLONG` on deep realm folders —
+the exact hazard the global location eliminates.


### PR DESCRIPTION
## What

Move the five per-realm **runtime** artifacts out of the agent's realm folder and into a single **global, per-agent-namespaced** directory `~/.context-pilot/sync/<id>/`:

| Artifact | Before | After |
| --- | --- | --- |
| `bridge.lock` | `<realm>/bridge.lock` | `~/.context-pilot/sync/<id>/bridge.lock` |
| `oplog/` | `<realm>/oplog/` | `~/.context-pilot/sync/<id>/oplog/` |
| `stream.sock` | `<realm>/stream.sock` | `~/.context-pilot/sync/<id>/stream.sock` |
| `tee.sock` | `<realm>/tee.sock` | `~/.context-pilot/sync/<id>/tee.sock` |
| `heartbeat` | `<realm>/heartbeat` | `~/.context-pilot/sync/<id>/heartbeat` |

`<id>` is the agent's `folder_id` (FNV-1a of the canonical realm path) — the **same** id the registry already uses at `~/.context-pilot/agents/<id>.json`, so the sync plane sits right next to the discovery record.

## Why

- **Keeps the user's project tree clean** — nothing is written into the realm folder anymore.
- **Bounds the Unix-socket path length** (`sun_path` ~104 bytes) regardless of realm depth — the global path is short and fixed, retiring the `ENAMETOOLONG` `bind` hazard a deep realm could trigger.
- **Consistent with the already-global registry.**

Full design + rationale: `docs/design-sync-dir-migration.md`.

## Changes

**`cp-wire`** — `Entry` gains `tee_socket_path: String` (`#[serde(default)]` for N-1 compat). The tee socket is now **advertised** rather than reconstructed by name from `folder` (it's no longer under `folder`). Exhaustive-struct justification 14→15; round-trip + extra-fields tests extended (old entry with no field decodes to `""`).

**`cp-orchestrator`**
- `TeeReader::spawn` takes the full tee socket path (not a folder).
- `driver.rs::resolve_tee_path` uses `entry.tee_socket_path` when present, else falls back to `folder + tee.sock` — so a **new orchestrator still serves un-migrated agents**.
- New `FleetScanner::reap_orphan_sync_dirs` (7-day grace, `DEFAULT_SYNC_ORPHAN_GRACE`) collects `sync/<id>/` dirs left behind by deleted realms; wired into the slow driver cadence.
- All other consumers (`channel`/`metrics`/`liveness`/`vitals`) are already path-agnostic (they read absolute paths from the registry) — **no change**.

**`cp-mod-bridge`**
- `registry::default_sync_root` helper (`$HOME/.context-pilot/sync`, sibling of the agents dir).
- `start_inner` takes a `BootDirs { agents_dir, sync_root }` param struct (dodges `too_many_arguments`), builds `<sync_root>/<id>/`, `create_dir_all`s it **before** the lock, and writes every artifact under it. The registry entry then advertises the new absolute paths automatically.
- `migrate::migrate_oplog` — one-time relocation of a pre-T713 `<realm>/oplog` into the sync dir: atomic `rename` fast path, **`EXDEV` cross-device fallback** = recursive copy + fsync-each-file + fsync-dir + remove-source (crash-safe: source is only removed after a durable copy).
- Boot tests moved to `boot/tests.rs` to respect the 500-line file cap.

## Rollout (orchestrator-first, M177)

1. **Ship the orchestrator first** — it reads `tee_socket_path` when present and falls back otherwise, so it fully serves both migrated and un-migrated agents.
2. **Ship the agent second** — it writes under `sync/<id>/`, advertises the new paths, and runs the one-time oplog move.
3. Verify: registry entry shows `sync/<id>/` paths; heartbeat/liveness green; open a thread and confirm live token streaming (tee plane); confirm the realm folder no longer gains runtime artifacts.

## Verification

- `cargo build -p cp-wire -p cp-orchestrator -p cp-mod-bridge` — clean.
- `cargo test -p cp-wire -p cp-mod-bridge -p cp-orchestrator` — all suites green (incl. new migrate, boot-under-sync-dir, orphan-reaper, tee-path-resolve tests).
- `cargo clippy --workspace --all-targets` — 0 errors.
- `api-contract` callback green (no openapi/TS drift).
- Structure caps respected (all files ≤500 lines, `boot/` ≤8 entries).
