### PR TITLE
feat(todo): structured upsert tool + unified, self-collapsing task recaps

### DIFF
--- a/.context-pilot/shared/memories.yaml
+++ b/.context-pilot/shared/memories.yaml
@@ -500,10 +500,12 @@ M-short-4:
   last_edited_ms: 0
 M-short-40:
   tier: short
-  title: T686b id-as-key Todo
-  contents: 'T686b SHIPPED (todo-v3-yaml-diffs): Todo canonical YAML 1st line = ''- {id}: {status}'' (id=mapping KEY, val=status); title/desc/children siblings. Flip = tiny inline diff {prev:''X41: in_progress'',new:''X41: done''}. yaml.rs manual serde_yaml::Value parser (dropped serde derive). Create=omit id line, 1st key title:. core.yaml desc: id-anchored inline edits + stale-panel warn. Builds on T686 tree.'
+  title: Todo upsert + recap strip
+  contents: |-
+    Todo tool = structured upsert (PR #194, killed YAML diffs): `items`, id=update / no-id=create, nesting=parenthood, merge-not-replace, delete=cancelled, atomic.
+    Recap: tree::result_annex sole producer, <!--TODO_RECAP--> framed. strip_superseded keeps only the last + returns touched indices so checks.rs re-persists. Gated queue-idle AND tempo-broken.
   importance: high
-  last_edited_ms: 1787949116200
+  last_edited_ms: 1788958686987
 M-short-5:
   tier: short
   title: 'Datalab OCR API: POST'
@@ -581,10 +583,10 @@ M-tiny-14:
   last_edited_ms: 1787840930941
 M-tiny-15:
   tier: tiny
-  title: Active branch
-  contents: 'ACTIVE WORKING BRANCH = ''todo-v3-yaml-diffs'' (off fresh master, T682 Todo YAML-diff redesign). Previous todo-v2 PR #188 MERGED to master. Push here + open new PR unless told otherwise.'
+  title: 'Active branch + PR #194'
+  contents: 'Branch t715-orch-reader-rebuild → PR #194 OPEN to master (8 commits). Branch name is REUSED: its first PR #193 (T715) is already MERGED. Push here unless told otherwise.'
   importance: critical
-  last_edited_ms: 1787935261012
+  last_edited_ms: 1788958673116
 M-tiny-16:
   tier: tiny
   title: Freeze RESOLVED at infra

--- a/.context-pilot/shared/memories.yaml
+++ b/.context-pilot/shared/memories.yaml
@@ -83,10 +83,14 @@ M-long-8:
   last_edited_ms: 1788350028141
 M-long-9:
   tier: long
-  title: MULTI-WORKER (subworkers
-  contents: 'MULTI-WORKER (subworkers branch, off master): N equal workers, true concurrency, single main loop. Design doc: docs/design-subworkers.md. 14 shared modules, 8 per-worker.'
-  importance: critical
-  last_edited_ms: 0
+  title: T724 spine↔thread map
+  contents: |-
+    T724 spine↔threads linkage ANALYSIS (no code yet). Spine 2 planes: notifications (SpineState::create_notification -> injects into GLOBAL state.messages + auto-cont engine.rs push_user_message) + WatcherRegistry (poll_all @ cleanup.rs check_watchers; async watcher fire -> create_notification(Custom,'watcher')). Neither WatcherResult(cp-base carriers.rs) nor Notification(spine types.rs) carries thread_id.
+    5 Watchers: Coucou(coucou.rs:448, HAS thread_id but only decorates text), Channel(cp-base async_exec:143), Ocr(ocr tools:164), Console(console tools x3), Callback(callback firing:186).
+    ~11 create_notification sites: input.rs:137(UserMsg), engine.rs:85(guardrail), cleanup.rs:117(watcher chokepoint), checks.rs:143(todo_hygiene HAS tid), lifecycle.rs:126(ReloadResume), reverie.rs x4, questions:183(ThinkReminder).
+    Delivery = ThreadMessage::user(content)->thread.messages.push+status=MyTurn (idle auto-cont picks up). Natural link=FocusState.focused_thread_id(Option). Classes: already-linked=Coucou+todo_hygiene; via-focus=Channel/Ocr/Console/Callback/ThinkReminder; meta-global=guardrail/ReloadResume/reverie x4. Blocking watchers resume pipeline, never post (linkage!=delivery).
+  importance: high
+  last_edited_ms: 1788362763224
 M-mid-1:
   tier: mid
   title: 'DOCUMENTATION QUALITY:'
@@ -397,10 +401,10 @@ M-short-25:
   last_edited_ms: 0
 M-short-26:
   tier: short
-  title: Library panel YAML
-  contents: 'T720 SHIPPED (f3e4aab5, t715-orch-reader-rebuild): Library fixed panel renders YAML-style (agents:/skills:/commands: seqs), not Markdown tables. library_panel.rs context()=push_*_yaml + yaml_scalar() + # cheatsheet; library_blocks.rs=kv_line/bool_line/entry_line Block::Line (bool green-when-true).'
+  title: Console timeout mislabel
+  contents: '''Callback result unavailable (timeout)'' is MISLABELED for console tools. force_resolve_stragglers (cleanup.rs): content==SENTINEL->''Console wait unavailable''; SENTINEL+tail->''Callback...''. Tail=appended pre-flight warning. console_easy_bash IS blocking (10s deadline, bare sentinel). Hung cmd (psql on stuck lock) + lost watcher/relay stall->force-resolve mislabel.'
   importance: medium
-  last_edited_ms: 1788360268582
+  last_edited_ms: 1788365521867
 M-short-27:
   tier: short
   title: T584 tool-call UI

--- a/.context-pilot/shared/tree-descriptions.yaml
+++ b/.context-pilot/shared/tree-descriptions.yaml
@@ -1298,6 +1298,10 @@
   path: .context-pilot/scripts/rust-check.sh
   description: 'CB4 callback script. Runs 3 checks on every .rs edit: (1) cargo fmt --check, (2) cargo check -D warnings, (3) cargo clippy --all-targets -D warnings. Matches CI ci.yml steps. Fmt check added T462 (was missing since June 5 consolidation).'
   last_edited_ms: 1782897541690
+0d297dbb9cc3fb1a:
+  path: src/app/run/tools/pipeline.rs
+  description: Main tool execution pipeline. collect_tool_results(ToolBatch) + finalize_tool_cycle(ToolCycle) split from handle_tool_execution (A2). execute_one_tool/execute_queue_control/enqueue_tool. Pre-flight → queue intercept (auto-flush on trap defusal) → execute → callbacks(sibling) → tempo. Radar signals, Meili log sync.
+  last_edited_ms: 0
 0d2b3a98d6478358:
   path: src/llms/oai_providers/grok.rs
   description: xAI Grok client. OpenAI-compatible API. Shared openai_compat message building + openai_streaming::consume_sse_stream (A2 loop extracted). API key from vault ("xai").
@@ -3269,6 +3273,10 @@
 221a789696c80caf:
   path: .git/index
   description: Git index (binary). Not source.
+  last_edited_ms: 0
+221ed08b18b2d926:
+  path: src/app/run/tools/checks.rs
+  description: 'Post-tool non-blocking polls: panel readiness (5s timeout), deferred sleep timer. Each resumes streaming pipeline when condition met. Imports has_dirty_panels from streaming.rs.'
   last_edited_ms: 0
 222420220afa8c94:
   path: crates/cp-base/Cargo.toml
@@ -12134,6 +12142,10 @@
   path: ui/src/components/finder/FinderChrome.tsx
   description: 'Finder chrome: FinderTabs (tab strip + new/close), FinderToolbar (back/fwd, breadcrumb, grid/list/columns seg, search, upload/download, preview toggle), FinderSidebar (Realm places + favorites + ''confined realm'' note).'
   last_edited_ms: 1781516507767
+7cd5d3d3f80f5ef8:
+  path: .git/index
+  description: Git index (binary). Not source.
+  last_edited_ms: 0
 7cdf399a812f80da:
   path: crates/cp-base/src/state/watchers.rs
   description: Watcher trait + WatcherRegistry. WatcherResult (description/panel_id/tool_use_id/close_panel/create_panel/create_dyn_panel/kill_session/preserves_tempo). poll_all() drains, uses route_result() free fn to split blocking/async (A2 cognitive). ChannelWatcher polls Mutex<Receiver> for async tool results. ASYNC_ERROR_PREFIX + DYN_PANEL_ID_PLACEHOLDER.
@@ -12858,6 +12870,10 @@
   path: .git/index
   description: Git index (binary). Not source.
   last_edited_ms: 0
+844949347b8d6db8:
+  path: src/modules/questions/think.rs
+  description: ThinkState (count/threshold/next_notification_at), execute() increments counter + encouraging status
+  last_edited_ms: 0
 8450887d84aa9bc0:
   path: crates/cp-orchestrator/src/transport/rest/thread_shape.rs
   description: 'Pure thread-list shaping: overlay_roster merges live view roster into disk threads (refresh status/archived/lastActivity; synthesize log-less ThreadDetail for view-only threads = instant appearance), reshape_thread/reshape_message snake_case→camelCase maquette shape.'
@@ -13254,6 +13270,10 @@
   path: src/modules/mod.rs
   description: 'Module registry. 24 modules via all_modules(). A9: lookup.get(|entry|) index. dispatch_tool w/ flame, create_panel factory, module_toggle, rebuild_tools, dependency validation.'
   last_edited_ms: 1784541442951
+883ae55f4077ee32:
+  path: .git/index
+  description: Git index (binary). Not source.
+  last_edited_ms: 0
 883aff42ef096a25:
   path: crates/cp-mod-git/Cargo.toml
   description: 'Git module deps: cp-base, cp-render, cp-vault, crossterm, serde_json, regex.'
@@ -14633,6 +14653,10 @@
 965292c5106e02e5:
   path: crates/cp-render/src/frame.rs
   description: Frame-level IR types. Frame (sidebar/active_panel/status_bar/conversation/overlays), Sidebar (entries/token_bar/stats/pr_card/help), StatusBar (badge/agent/skills/git/auto_continue/reverie/queue/think), PanelContent (title/blocks).
+  last_edited_ms: 0
+9654871f79dc80dd:
+  path: src/app/run/tools/checks.rs
+  description: 'Post-tool non-blocking polls: panel readiness (5s timeout), deferred sleep timer. Each resumes streaming pipeline when condition met. Imports has_dirty_panels from streaming.rs.'
   last_edited_ms: 0
 965616ec4b09320a:
   path: tmp/doc/template/header.html
@@ -18394,6 +18418,10 @@ bd18738f5448aac7:
   path: web/src/components/finder/preview/livePreviews.tsx
   description: 'Live-data Finder previews: LivePreview/LiveImagePreview/LivePdfPreview/LiveSheetPreview/HighlightedCode/EditableMarkdown. LiveSheetPreview delegates to Univer-based SheetGrid (replaced AG Grid). Sheet tabs handled natively by Univer. T329: all card chrome stripped for full-bleed.'
   last_edited_ms: 1784135961101
+bd1d5425f884904e:
+  path: crates/cp-mod-todo/src/lib.rs
+  description: Todo module. 3 tools create/update/move. Fixed TODO panel (fixed_order=0). pre_flight split preflight_create/update/move. todo_line_semantic split keyword_semantic/tail_semantic (A2). Drives spine auto-continuation.
+  last_edited_ms: 0
 bd217dcc3a74f32b:
   path: crates/cp-orchestrator/tests/openapi/schemas_ext.rs
   description: Transport-layer OpenAPI schemas — receipts, auth, env-keys, filesystem, FinderKind enum, LLM registry (ModelDef/ProviderDef), SSE delta protocol, release management, Claude Code usage+login (ClaudeTokenStatus/LoginStart/LoginComplete schemas).

--- a/.context-pilot/shared/tree-descriptions.yaml
+++ b/.context-pilot/shared/tree-descriptions.yaml
@@ -166,6 +166,10 @@
   path: crates/cp-wire/Cargo.toml
   description: Wire protocol crate manifest. No deps yet (I/O-free). Workspace lints inherited.
   last_edited_ms: 1781615263418
+01c908b86bd6bbe6:
+  path: crates/cp-wire/src/types/snapshot/roster_builder.rs
+  description: RosterThreadBuilder — fluent builder for RosterThread (#[non_exhaustive]). 3 required fields (thread_id, name, status) + 6 optional state fields (archived, paused, last_activity_ms, msg_count, tasks, notes) defaulting to zero.
+  last_edited_ms: 1788445206285
 01c9acde916b2769:
   path: web/src/components/finder/views/FinderViews.tsx
   description: Finder grid/list/gallery views + Head/Hero. Re-exports only ColumnsView (a component) from ./ColumnsView; non-component shared symbols (MIME consts/ViewHandlers/TagDots) are imported directly from ./helpers or ./shared by consumers (web-lint P0 Fast-Refresh purity).
@@ -890,6 +894,10 @@
   path: crates/cp-orchestrator/src/transport/mod.rs
   description: Frontend transport REST+SSE over tiny_http. MAX_BODY=32MiB. route_rest dispatches all /api routes incl auth/ACL/env-keys/providers/releases/claude-usage+login+refresh(T451). handle() has centralized Bearer gate + per-agent ACL check. handle_stream = SSE with ticket-based ACL.
   last_edited_ms: 0
+08c01c4668481681:
+  path: web/src/mobile-components/threads/fileUpload/ThreadAsideRail.tsx
+  description: Mobile-mirror stub re-exporting desktop ThreadAsideRail (CB3 parity).
+  last_edited_ms: 1788445206510
 08c0f5671fcadd3a:
   path: crates/cp-base/src/state/context.rs
   description: 'Kind registry + Entry type. TypeMeta 9-field #[expect(exhaustive_structs)] A5 (25 cross-crate sites). A6: estimate_tokens via float_math::ceil_ratio. EmittedState/ScrollState/Entry #[non_exhaustive]+builders. make_default_entry.'
@@ -953,6 +961,10 @@
 095cb2628a4c1c86:
   path: .context-pilot/shared/entities/schema.sql
   description: 'Auto-generated SQLite dump: CREATE + INSERT for all entity tables. Recovery source for DB corruption/deletion.'
+  last_edited_ms: 0
+0960d2f61b280d1a:
+  path: .git/index
+  description: Git index (binary). Not source.
   last_edited_ms: 0
 0960dac941a1a564:
   path: crates/cp-mod-scratchpad/src/tools.rs
@@ -2410,6 +2422,10 @@
   path: src/modules/pre_flight.rs
   description: 'Pre-flight validation: Phase 0 trap block, Phase 0.25 compulsory intent/verb (blocking), Phase 0.5 duplicate Close_conversation_history queue check, Phase 1 schema validation, Phase 2 module semantic checks.'
   last_edited_ms: 1781345577275
+18bf62189754d6ad:
+  path: .context-pilot/shared/memories.yaml
+  description: Memory slots store (M-safe/tiny/short/mid/long, 220 fixed). Local-only, synced with commits. Mirrors the Memories panel.
+  last_edited_ms: 0
 18c21816f2d77478:
   path: yamls/injections.yaml
   description: LLM-facing text injections. Spine auto-continuation, editor warning banners, console guardrails (git/gh/typst → dedicated tools), history cleanup trap messages (%PANELS% templates), behavioral redirects, provider-shared text.
@@ -3382,6 +3398,10 @@
   path: web/src/components/finder/Finder.tsx
   description: Per-agent Finder file manager (493 LOC). Owns view state + derived listings + render; delegates fs mutations/nav to useFinderActions, selection/open/tab/menu to useFinderSelection, keyboard to useFinderKeyboard, external drag to useExternalDragUpload, DOWNLOADS to useFinderDownloads (web-lint P2 split), bottom chrome to FinderOverlays. QuickLook = modal shadcn Sheet (grid+list). T334 revealPath navigates to a file's parent + selects it.
   last_edited_ms: 0
+236af28fcaa886bd:
+  path: crates/cp-wire/src/types/snapshot/notes.rs
+  description: 'WireNote — thread-owned scratchpad cell projection (3-field: id, title, content). Flat wire value object built by struct literal cross-crate (#[expect exhaustive_structs]). Twin of WireTask.'
+  last_edited_ms: 1788445206366
 236d71ab8addd32d:
   path: web/src/components/finder/views/shared.tsx
   description: 'Shared Finder-view COMPONENTS only (react-refresh purity): RenameInput (inline rename field) + TagDots (macOS tag dots). Non-component helpers moved to ./helpers.ts.'
@@ -5310,6 +5330,10 @@
   path: web/src/components/finder/preview/SheetGrid.tsx
   description: 'Univer spreadsheet viewer/editor. Full spreadsheet engine: range selection, formatting, formulas, sheet tabs, merge cells, context menus, undo/redo — all free Apache 2.0 tier. Mounts Univer via createUniver + UniverSheetsCorePreset. FR locale. Explicit Save button uploads modified XLSX (via ExcelJS) to agent realm; wipes localStorage on save so next mount loads from remote (single source of truth). localStorage kept as crash-recovery only.'
   last_edited_ms: 0
+37064c8abcae1fa4:
+  path: web/src/components/threads/fileUpload/ThreadAsideRail.tsx
+  description: ThreadAsideRail (T662 aside + T677 show/hide chrome). Slidable rail (neg margin-right off right edge) + floating reopen button. ⌘/Ctrl+H toggle via useModifierShortcuts+HintBadge. Width mirrors preview state (40vw/50vw).
+  last_edited_ms: 0
 3707ddc0ffc94b7a:
   path: web/src/lib/query/sync.ts
   description: SSE→QueryClient delta bridge (push plane). qk registry, ensureSync, applyDelta functional-updater fold, hydrateSpilledMessage (T357), throttledInvalidateInspection (T492). Re-exports reducers+OpEntry.
@@ -5653,6 +5677,10 @@
 3a1a5897bc4a2ee9:
   path: .github/workflows/build.yml
   description: 'Cross-platform build workflow. 4-target matrix: linux-x86_64 (native), linux-aarch64 (cross), macos-x86_64 (macos-13), macos-aarch64 (macos-latest). Pins Rust 1.93.0. Builds tui + cp-console-server. 30-day artifact retention.'
+  last_edited_ms: 0
+3a2d6934fd61f513:
+  path: web/src/components/threads/fileUpload/ThreadAsideTasks.tsx
+  description: 'ThreadAside Tasks+Notes tab bodies (T662/T716): TaskList (read-only todo tree, auto-collapse of all-done/all-planned branches, snake-border in-progress icon) + NoteList (thread scratchpad cells, list→click-expand content, StickyNote icon). NoteList co-located here (not own file) to respect the 8-entry dir cap. Both purely presentational, fed by task_list_changed / notes_changed deltas.'
   last_edited_ms: 0
 3a31b624353a7393:
   path: crates/cp-orchestrator/src/services/auth/mod.rs
@@ -7025,6 +7053,10 @@
 484c8d2183d5aee3:
   path: web/src/components/shell/config/DeploySection.tsx
   description: 'Deploy actions for Releases settings pane. Two buttons: "Deploy to Fleet" (POST /api/releases/deploy, select+restart all agents) and "Restart Orchestrator" (POST /api/releases/restart-orchestrator, delayed SIGTERM, auto-reload after 3s). Click-to-confirm guard on orchestrator restart. Uses generated SDK.'
+  last_edited_ms: 0
+485c10071663ac1d:
+  path: src/app/run/tools/cleanup.rs
+  description: 'Watcher polling: blocking sentinel replacement + async spine notifications. A2 split + A9 clean (dp.metadata for entry index, result.as_ref/as_mut, pending_done take).'
   last_edited_ms: 0
 485de9616dce1334:
   path: crates/cp-mod-todo/src/tools.rs
@@ -9270,6 +9302,10 @@
   path: crates/cp-base/src/modules.rs
   description: Module trait — pluggable functionality contract. init/save/load state, tool definitions/execution/pre-flight, panel creation, overview delegation, lifecycle hooks (on_user_message/stream_stop/tool_progress), file watcher integration.
   last_edited_ms: 0
+607a6e0c48c3ab74:
+  path: crates/cp-mod-todo/src/lib.rs
+  description: Todo module. 3 tools create/update/move. Fixed TODO panel (fixed_order=0). pre_flight split preflight_create/update/move. todo_line_semantic split keyword_semantic/tail_semantic (A2). Drives spine auto-continuation.
+  last_edited_ms: 0
 607f22770ef36ba3:
   path: crates/cp-base/src/config/models.rs
   description: '6 per-provider model enums (Anthropic/Grok/Groq/DeepSeek/MiniMax/ClaudeCodeV2) all #[expect(exhaustive_enums)] A4. ClaudeCodeV2Model = 6 variants (Opus5 default/Opus48/Opus46/Sonnet5/Fable5/Haiku45), all bare api_name IDs. Pricing/context/api-names.'
@@ -9301,6 +9337,10 @@
 60bad2b9bbf7560b:
   path: crates/cp-mod-search/src/panel.rs
   description: Search result panel + YAML formatter. format_results() groups file chunks by path, includes log entries. visualize_search_output() for conversation view highlighting. Same metadata persistence pattern. No tags.
+  last_edited_ms: 0
+60e3aaa0f8d799ba:
+  path: yamls/tools/core.yaml
+  description: 'Core tools YAML: Close_panel, system_reload, panel_goto_page, Think, Todo (YAML-diff task edits). tool_manage/module_toggle removed (T705).'
   last_edited_ms: 0
 60e6716a3768b76c:
   path: crates/cp-mod-bridge/src/error.rs
@@ -11758,6 +11798,10 @@
   path: crates/cp-mod-scratchpad/Cargo.toml
   description: 'Scratchpad module deps: cp-base, cp-render, crossterm, serde, serde_json.'
   last_edited_ms: 1780563847629
+7925778237f8df8f:
+  path: Cargo.lock
+  description: Workspace lockfile
+  last_edited_ms: 0
 7952b9cd83db7d07:
   path: crates/cp-mod-git/src/tools.rs
   description: Git tool. Read-only → dynamic git_result panels. Mutating → async subprocess via spawn_async_tool. flame!("git_exec"). GIT_ASKPASS temp script for HTTPS auth. Cache invalidation via regex patterns.
@@ -12562,6 +12606,10 @@
   path: crates/cp-wire/src/types/oplog/mod.rs
   description: OpEntryKind (internally-tagged, Unknown catch-all) + OpEntry. todo-v2 adds TaskListChanged{thread_id,tasks:Vec<WireTask>} (whole-list snapshot, durable roster state). oplog.rs split to oplog/ dir for 500-line cap.
   last_edited_ms: 0
+819b5e33089514fd:
+  path: crates/cp-mod-todo/Cargo.toml
+  description: 'Todo module deps: cp-base, cp-render, crossterm, serde, serde_json.'
+  last_edited_ms: 0
 81a162f1e0d9a52e:
   path: src/app/context/mod.rs
   description: Context preparation + unified freeze system. FreezeConditions (queue/tempo). Panel ordering stabilization. Per-panel content hashing + freeze budgets. Cache cost tracking via prefix-match. flame!("prepare_context"). Reverie path branches.
@@ -12765,6 +12813,10 @@
 83f75d19faa58d37:
   path: crates/cp-wire/src/types/registry.rs
   description: 'Entry struct #[expect(exhaustive_structs)] A5 (14-field, 13-arg ctor trips too_many_arguments). AgentStatus enum #[expect(exhaustive_enums)] A4.'
+  last_edited_ms: 0
+83fefe79bb6195e0:
+  path: yamls/tools/threads.yaml
+  description: 'Threads tools YAML. 2 tools: Send (thread_id, markdown, file_path, questions), Read (thread_id, count).'
   last_edited_ms: 0
 84010ff7379a6553:
   path: web/src/components/threads/ThreadList.tsx
@@ -15162,6 +15214,10 @@
   path: openapi.json
   description: Generated OpenAPI 3.0.3 spec (70KB). Source of truth for TypeScript client codegen. Regenerated from Rust types via tests/openapi.rs.
   last_edited_ms: 0
+9d2dd2f53779c9cf:
+  path: web/src/mobile-components/threads/fileUpload/useThreadAside.ts
+  description: Mobile-mirror stub re-exporting desktop useThreadAside (CB3 parity).
+  last_edited_ms: 1788445206580
 9d3c75b6217673cd:
   path: crates/cp-mod-tree/src/panel.rs
   description: Tree panel. Background cache system for directory tree rendering. TreeCacheRequest data payload. Pagination. refresh_stale_from_yaml() call in apply_cache_update triggers second rebuild if descriptions changed.
@@ -15938,6 +15994,10 @@ a467728cf80828fe:
   path: web/tsconfig.app.json
   description: 'App-scope TS compiler config (bundler mode, react-jsx, es2023). Current strictness: noUnusedLocals/Parameters, erasableSyntaxOnly, noFallthroughCasesInSwitch, verbatimModuleSyntax. T505 target: add the full maximal strict superset (noUncheckedIndexedAccess, exactOptionalPropertyTypes, noImplicitReturns/Override, noPropertyAccessFromIndexSignature, etc.) — the rustc-forbid twin.'
   last_edited_ms: 1783348132288
+a4747c073a515243:
+  path: src/modules/questions/mod.rs
+  description: 'QuestionsModule: core, 1 tool (Think only). ThinkState persistence, on_tool_complete counter drift. No ask_user_question tool. Uses core.yaml for tool texts.'
+  last_edited_ms: 0
 a47504396e170036:
   path: src/ui/help/input.rs
   description: 'Question form and autocomplete popup overlays. Adapter layer: renders QuestionForm and Autocomplete IR data to ratatui widgets. No direct State access. Used by threads_view.rs for thread-embedded question forms.'
@@ -16185,6 +16245,10 @@ a6e931ee84d698fc:
 a6f9367d3075fc36:
   path: src/app/actions/mod.rs
   description: 'Central action dispatch (Elm/Redux-style). Maps Action variants to state mutations. Delegates to sub-modules: input, streaming, config, cursor, history, navigation. Selection-aware InputChar/Delete/InsertText/PasteText. @-autocomplete trigger. Scroll acceleration.'
+  last_edited_ms: 0
+a702c442530ac2de:
+  path: .git/index
+  description: Git index (binary). Not source.
   last_edited_ms: 0
 a73611bc3edabdd9:
   path: src/app/run/threads.rs
@@ -17814,6 +17878,10 @@ b7c0f401af835c5a:
   path: crates/cp-mod-firecrawl/src/types.rs
   description: Firecrawl response types. ScrapeResponse/Data/Metadata, SearchResponse/SearchResult (polymorphic data field), MapResponse/MapLink, CrawlStartResponse/CrawlStatusResponse/CrawlPageData. All Serialize+Deserialize.
   last_edited_ms: 0
+b7c97fb6480b1eba:
+  path: src/modules/questions/think.rs
+  description: ThinkState (count/threshold/next_notification_at), execute() increments counter + encouraging status
+  last_edited_ms: 0
 b7da902dc1b1473f:
   path: crates/cp-mod-entities/src/tools/mod.rs
   description: 'entity_sql dispatch: parse_inputs (ParamFlags mutual-exclusion validate, resolve_sql_text), classify_and_check, run_statement (dry-run/SELECT/DML/DDL via ExecPlan), route_ok (live/output/inline via RouteCtx), post-exec sync_affected + refresh_schema_cache. INLINE_MAX 150 lines/8000 bytes.'
@@ -18546,6 +18614,10 @@ bf3bc897b04b85cc:
   path: src/app/context/mod.rs
   description: 'Context prep + unified freeze. A9: full_freeze snapshot via state.frozen_context_snapshot.as_ref(). prepare_stream_context split reverie/main builders; freeze machinery in sibling freeze_pass.rs.'
   last_edited_ms: 1784541443031
+bf3dc76aa2b52e24:
+  path: web/src/lib/query/taskReducer.ts
+  description: 'task_list_changed SSE delta fold: normalizes wire snake_case parent_id → camelCase parentId (RawTask→ThreadTask) so nesting survives the live delta path. foldTaskList replaces a thread''s tasks wholesale.'
+  last_edited_ms: 1788445206439
 bf406b036b3524d3:
   path: .context-pilot/shared/memories.yaml
   description: Memory slots store (M-safe/tiny/short/mid/long, 220 fixed). Local-only, synced with commits. Mirrors the Memories panel.
@@ -18818,6 +18890,10 @@ c25a2124eedb1bf7:
   path: web/vite.config.ts
   description: 'Vite dev config. T310: single-origin tailnet serving — server.allowedHosts:true (accept the macbook.<tailnet>.ts.net Host from `tailscale serve`''s reverse proxy, anti-DNS-rebinding relaxed since the server binds 127.0.0.1 and is exposed only over the private WireGuard tailnet) + server.proxy ''/api''→http://127.0.0.1:7878 (REST + /api/stream SSE) so the frontend uses a RELATIVE base (VITE_API_URL="" in .env.local) and the app works identically at localhost:5174 or https://<host>.ts.net (phone access) with no CORS/mixed-content. @ alias → ./src.'
   last_edited_ms: 1782062124437
+c26cab575bc262f7:
+  path: crates/cp-base/src/state/watchers/carriers.rs
+  description: WatcherResult + DeferredPanel + DynPanel carriers. Builder-pattern result type with panel_id/tool_use_id/close_panel/create_panel/processed_already/kill_session/preserves_tempo/create_dyn_panel fields.
+  last_edited_ms: 1788445206650
 c2799064465c4c10:
   path: crates/cp-orchestrator/src/services/releases/mod.rs
   description: Local release management — architecture detection, GitHub release listing, download + extraction, and active-binary selection. ReleaseStore manages ~/.context-pilot/releases/ directory. KNOWN_ARCHS, semver_sort_key(). 7 unit tests.
@@ -20373,6 +20449,10 @@ d2cee02ff9d7b51f:
 d2d0808774f88ec3:
   path: run.sh
   description: Development run script
+  last_edited_ms: 0
+d2d9e5d6716ba414:
+  path: .git/index
+  description: Git index (binary). Not source.
   last_edited_ms: 0
 d2da1ecfe1251957:
   path: web/src/components/finder/FinderChrome.tsx
@@ -22249,6 +22329,10 @@ e7e07b3150bce322:
 e7e9608a46d53f56:
   path: src/app/run/threads/mod.rs
   description: 'Thread helpers for main loop: maybe_inject_auto_read (filters paused threads — T371), check_my_turn_threads (filters paused threads — T371), extract_thread_ids, maybe_append_tool_activity. emit_thread_paused re-exported from paused.rs.'
+  last_edited_ms: 0
+e80c7001f3927f71:
+  path: web/src/components/threads/fileUpload/ThreadAside.tsx
+  description: 'ThreadAside (T662): single right rail, Tasks+Files tabs (per-section presence gates). Files tab clicks swap to inline FinderPreview (variant=full, own header suppressed), rail widens 40vw/50vw. AsideTabBar with Download/Back/Hide cluster. Controlled tab+selection.'
   last_edited_ms: 0
 e8126b504f1b46e4:
   path: src/ui/ir/mod.rs
@@ -24242,6 +24326,10 @@ fb9ce968c3ad6157:
   path: crates/cp-mod-bridge/src/lib.rs
   description: 'BridgeModule: init_state activates Boot when CP_BRIDGE=1 OR --bridge CLI flag. MemoSeeds u8 bitfield (5 flags: messages/statuses/focus/archived/paused) with const accessor/seed methods. BridgeState includes thread_paused_memo HashMap + seeded:MemoSeeds. PENDING+try_recover self-heal.'
   last_edited_ms: 1782311327163
+fbb0db61c783b876:
+  path: web/src/components/threads/ThreadConversation.tsx
+  description: 'Center pane: thread conversation + composer. T510 FREEZE FIX = MessageRow React.memo + AutoRun memo + useMemo(segmentLog). T643: content-visibility removed from rows. T644 FIREFOX BLANK FIX: <main> filter no longer permanently blur(0px) — applied ONLY while dragging. Permanent blur(0px) is non-none, promoting the whole (up to ~100k px tall) conversation to ONE GPU layer; on a big thread that exceeds Firefox''s max GPU texture size, so a repaint from any interaction (ticking a form checkbox) fails texture allocation and FF paints <main> BLANK with DOM intact (recovered only by scroll-resetting refresh). Chromium/WebKit tile differently, never hit it; headless FF software-composites, never repros — which is why every innerHTML-based repro looked clean (paint bug invisible to DOM). useConversationDrop hook (T367/T471). FileSidebar rail.'
+  last_edited_ms: 0
 fbb69ddde0f9c6f6:
   path: ui/src/components/agents/PromptModal.tsx
   description: 'Prompts page modals (design-only). PromptModal: LARGE dialog (1180x90vh, max 96vw) — create (kind picker System/Skill/Command + name/description) or view/edit (prefilled, built-in name lock, Delete). Body uses the WYSIWYG MarkdownEditor (flex-grows to fill height), not a textarea. ImportModal: import from other agentic systems (Claude Code/Codex/Cursor/Windsurf/Aider/Continue), per-row Imported state. Shared hand-rolled Backdrop (backdrop-fade+modal-pop) + Field. Used by PromptsPage.'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,6 @@ dependencies = [
  "crossterm",
  "serde",
  "serde_json",
- "serde_yaml",
 ]
 
 [[package]]

--- a/crates/cp-mod-todo/Cargo.toml
+++ b/crates/cp-mod-todo/Cargo.toml
@@ -16,7 +16,7 @@ cp-render.workspace = true
 crossterm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-serde_yaml.workspace = true
+
 
 [lints]
 workspace = true

--- a/crates/cp-mod-todo/src/lib.rs
+++ b/crates/cp-mod-todo/src/lib.rs
@@ -15,7 +15,9 @@ pub mod tools;
 pub mod tree;
 /// Todo state types: `TodoItem`, `TodoStatus`, `TodoState`.
 pub mod types;
-/// Virtual-YAML render + diff-apply + reconcile (the `Todo` tool's core).
+/// Structured nested upsert — the `Todo` tool's core.
+pub mod upsert;
+/// Canonical YAML render of a thread's task tree (feeds the Todo panel).
 pub mod yaml;
 
 use types::{TodoState, TodoStatus};

--- a/crates/cp-mod-todo/src/lib.rs
+++ b/crates/cp-mod-todo/src/lib.rs
@@ -9,6 +9,8 @@
 
 /// Panel implementation for the todo list view.
 mod panel;
+/// Collapsing of superseded task recaps in the live conversation.
+pub mod recap;
 /// Focus-scoping + legacy purge (`set_focus_filter`, `purge_threadless`).
 pub mod tools;
 /// Synthetic task-tree + in-progress-leaf warning for tool results (T686).

--- a/crates/cp-mod-todo/src/recap.rs
+++ b/crates/cp-mod-todo/src/recap.rs
@@ -1,0 +1,156 @@
+//! Conversation-level collapsing of superseded task recaps.
+//!
+//! Every task recap emitted into a tool result — by the `Todo` tool itself, or
+//! appended to a tool whose `task_id` flipped a task — is produced by
+//! [`result_annex`](crate::tree::result_annex) and framed by
+//! [`RECAP_OPEN`](crate::tree::RECAP_OPEN) /
+//! [`RECAP_CLOSE`](crate::tree::RECAP_CLOSE). Each new recap supersedes every
+//! earlier one: they are snapshots of the same tree, so all but the most recent
+//! are stale.
+//!
+//! [`strip_superseded`] walks the **live conversation** (never the frozen
+//! `ConversationHistory` panels, whose content is already compacted) and
+//! replaces every recap but the last with a one-line stub. On a long session
+//! this reclaims a few hundred tokens per superseded call and, more importantly,
+//! leaves exactly ONE task tree in context — so the model can't mistake a stale
+//! snapshot for current state.
+//!
+//! It lives beside the producer on purpose: writer and reader share the same
+//! sentinel constants, so the framing can never drift.
+//!
+//! # The caller owns the gating
+//!
+//! Rewriting old messages mutates the conversation **prefix**, which invalidates
+//! the LLM prompt cache from the earliest edited message onward. That is only
+//! acceptable on a tick where the cache is already being broken — the host crate
+//! calls this only when the queue is idle (no half-formed batch) and tempo is
+//! already broken. Do not call it on a tempo-preserving tick.
+//!
+//! The pass only rewrites `content` (what the model reads), never `display`
+//! (what the TUI renders), so the human keeps full scrollback.
+
+use cp_base::state::runtime::State;
+
+use crate::tree::{RECAP_CLOSE, RECAP_OPEN};
+
+/// Replaces a superseded recap. Carries no sentinel, so a stubbed result is
+/// invisible to the next scan — the pass is naturally idempotent.
+const STUB: &str = "[task recap superseded]";
+
+/// Collapse every task recap in the live conversation except the most recent.
+///
+/// Returns the number of recaps stubbed (0 when there was nothing to do — i.e.
+/// zero or one recap in the whole conversation).
+pub fn strip_superseded(state: &mut State) -> usize {
+    let total = count_recaps(state);
+    if total <= 1 {
+        return 0; // Nothing superseded — the only recap is the live one.
+    }
+
+    // Collapse the first `total - 1` occurrences in conversation order; the
+    // final one is the live tree and stays untouched.
+    let mut budget = total.saturating_sub(1);
+    let mut stripped = 0usize;
+    for msg in &mut state.messages {
+        for record in &mut msg.tool_results {
+            if budget == 0 {
+                return stripped;
+            }
+            let (rewritten, n) = collapse(&record.content, budget);
+            if n > 0 {
+                record.content = rewritten;
+                budget = budget.saturating_sub(n);
+                stripped = stripped.saturating_add(n);
+            }
+        }
+    }
+    stripped
+}
+
+/// Total number of well-formed recap blocks across the live conversation.
+fn count_recaps(state: &State) -> usize {
+    state
+        .messages
+        .iter()
+        .flat_map(|m| m.tool_results.iter())
+        .map(|r| collapse(&r.content, usize::MAX).1)
+        .fold(0usize, usize::saturating_add)
+}
+
+/// Replace up to `budget` recap blocks in `content` with [`STUB`], scanning left
+/// to right. Returns the rewritten string and how many were replaced.
+///
+/// An unterminated `RECAP_OPEN` (truncated content) stops the scan and leaves
+/// the remainder verbatim — never deletes to end-of-string.
+fn collapse(content: &str, budget: usize) -> (String, usize) {
+    if budget == 0 || !content.contains(RECAP_OPEN) {
+        return (content.to_owned(), 0);
+    }
+    let mut out = String::with_capacity(content.len());
+    let mut rest = content;
+    let mut count = 0usize;
+    while count < budget {
+        let Some(start) = rest.find(RECAP_OPEN) else { break };
+        let after_open = start.saturating_add(RECAP_OPEN.len());
+        let Some(offset) = rest.get(after_open..).and_then(|tail| tail.find(RECAP_CLOSE)) else {
+            break; // Unterminated block — leave the remainder untouched.
+        };
+        let end = after_open.saturating_add(offset).saturating_add(RECAP_CLOSE.len());
+        out.push_str(rest.get(..start).unwrap_or_default());
+        out.push_str(STUB);
+        rest = rest.get(end..).unwrap_or_default();
+        count = count.saturating_add(1);
+    }
+    out.push_str(rest);
+    (out, count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RECAP_CLOSE, RECAP_OPEN, STUB, collapse};
+
+    /// Build a recap block with `body` inside the sentinels.
+    fn block(body: &str) -> String {
+        format!("{RECAP_OPEN}\n{body}\n{RECAP_CLOSE}")
+    }
+
+    #[test]
+    fn collapse_replaces_up_to_budget_in_order() {
+        let content = format!("head {} mid {} tail", block("one"), block("two"));
+        let (out, n) = collapse(&content, 1);
+        assert_eq!(n, 1);
+        assert_eq!(out, format!("head {STUB} mid {} tail", block("two")));
+    }
+
+    #[test]
+    fn collapse_is_idempotent_on_stubbed_content() {
+        let (once, _n) = collapse(&block("one"), 1);
+        let (twice, n) = collapse(&once, 1);
+        assert_eq!(n, 0);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn collapse_leaves_unterminated_block_intact() {
+        let content = format!("head {RECAP_OPEN} dangling");
+        let (out, n) = collapse(&content, 1);
+        assert_eq!(n, 0);
+        assert_eq!(out, content);
+    }
+
+    #[test]
+    fn collapse_preserves_surrounding_text() {
+        let content = format!("Todo applied.\n\n{}", block("tree"));
+        let (out, n) = collapse(&content, 1);
+        assert_eq!(n, 1);
+        assert_eq!(out, format!("Todo applied.\n\n{STUB}"));
+    }
+
+    #[test]
+    fn collapse_zero_budget_is_a_noop() {
+        let content = block("one");
+        let (out, n) = collapse(&content, 0);
+        assert_eq!(n, 0);
+        assert_eq!(out, content);
+    }
+}

--- a/crates/cp-mod-todo/src/recap.rs
+++ b/crates/cp-mod-todo/src/recap.rs
@@ -15,6 +15,11 @@
 //! leaves exactly ONE task tree in context — so the model can't mistake a stale
 //! snapshot for current state.
 //!
+//! The edit lands on the **single source of truth**: it returns the messages it
+//! touched so the caller re-persists them. Memory and disk therefore never
+//! disagree, and each recap is collapsed exactly once in its lifetime rather
+//! than re-collapsed after every reload.
+//!
 //! It lives beside the producer on purpose: writer and reader share the same
 //! sentinel constants, so the framing can never drift.
 //!
@@ -37,34 +42,54 @@ use crate::tree::{RECAP_CLOSE, RECAP_OPEN};
 /// invisible to the next scan — the pass is naturally idempotent.
 const STUB: &str = "[task recap superseded]";
 
-/// Collapse every task recap in the live conversation except the most recent.
+/// Collapse every task recap in the live conversation except the most recent,
+/// returning the **positions of the messages whose content changed**.
 ///
-/// Returns the number of recaps stubbed (0 when there was nothing to do — i.e.
-/// zero or one recap in the whole conversation).
-pub fn strip_superseded(state: &mut State) -> usize {
+/// The caller MUST re-persist each returned message: the strip edits the single
+/// source of truth, so leaving disk un-updated would fork the conversation into
+/// a stripped in-memory copy and a full-recap on-disk one, and every reload
+/// would redo (and re-pay for) the same work. Positions are indices into
+/// `state.messages`, valid immediately on return — nothing mutates the vector in
+/// between.
+///
+/// Empty when there was nothing to do (zero or one recap in the conversation).
+pub fn strip_superseded(state: &mut State) -> Vec<usize> {
     let total = count_recaps(state);
     if total <= 1 {
-        return 0; // Nothing superseded — the only recap is the live one.
+        return Vec::new(); // Nothing superseded — the only recap is the live one.
     }
 
     // Collapse the first `total - 1` occurrences in conversation order; the
     // final one is the live tree and stays untouched.
     let mut budget = total.saturating_sub(1);
-    let mut stripped = 0usize;
-    for msg in &mut state.messages {
-        for record in &mut msg.tool_results {
-            if budget == 0 {
-                return stripped;
-            }
-            let (rewritten, n) = collapse(&record.content, budget);
-            if n > 0 {
-                record.content = rewritten;
-                budget = budget.saturating_sub(n);
-                stripped = stripped.saturating_add(n);
-            }
+    let mut touched: Vec<usize> = Vec::new();
+    for (idx, msg) in state.messages.iter_mut().enumerate() {
+        if budget == 0 {
+            break;
+        }
+        if collapse_message(msg, &mut budget) {
+            touched.push(idx);
         }
     }
-    stripped
+    touched
+}
+
+/// Collapse recaps in one message's tool results, drawing from `budget`.
+/// Returns whether any content was rewritten.
+fn collapse_message(msg: &mut cp_base::state::data::message::Message, budget: &mut usize) -> bool {
+    let mut changed = false;
+    for record in &mut msg.tool_results {
+        if *budget == 0 {
+            break;
+        }
+        let (rewritten, n) = collapse(&record.content, *budget);
+        if n > 0 {
+            record.content = rewritten;
+            *budget = budget.saturating_sub(n);
+            changed = true;
+        }
+    }
+    changed
 }
 
 /// Total number of well-formed recap blocks across the live conversation.
@@ -181,7 +206,9 @@ mod tests {
         state.messages.push(result_msg("R2", format!("Todo applied.\n\n{}", block("second"))));
         state.messages.push(result_msg("R3", format!("Todo applied.\n\n{}", block("third"))));
 
-        assert_eq!(strip_superseded(&mut state), 2);
+        // The two rewritten messages are reported so the caller can persist them;
+        // the message holding the live recap is NOT.
+        assert_eq!(strip_superseded(&mut state), vec![0, 1]);
 
         let got = contents(&state);
         let mut seen = got.iter();
@@ -198,7 +225,7 @@ mod tests {
         let only = format!("Todo applied.\n\n{}", block("only"));
         state.messages.push(result_msg("R1", only.clone()));
 
-        assert_eq!(strip_superseded(&mut state), 0);
+        assert!(strip_superseded(&mut state).is_empty());
         assert_eq!(contents(&state).first(), Some(&only));
     }
 
@@ -208,10 +235,11 @@ mod tests {
         state.messages.push(result_msg("R1", block("first")));
         state.messages.push(result_msg("R2", block("second")));
 
-        assert_eq!(strip_superseded(&mut state), 1);
+        assert_eq!(strip_superseded(&mut state), vec![0]);
         let after_first = contents(&state);
-        // Second pass finds a single surviving recap → nothing left to do.
-        assert_eq!(strip_superseded(&mut state), 0);
+        // Second pass finds a single surviving recap → nothing left to do, so
+        // nothing is reported and the caller performs no redundant save.
+        assert!(strip_superseded(&mut state).is_empty());
         assert_eq!(contents(&state), after_first);
     }
 
@@ -223,7 +251,7 @@ mod tests {
         state.messages.push(Message::new_tool_result("R1".to_owned(), None, vec![record]));
         state.messages.push(result_msg("R2", block("second")));
 
-        assert_eq!(strip_superseded(&mut state), 1);
+        assert_eq!(strip_superseded(&mut state), vec![0]);
 
         let first = state.messages.first().and_then(|m| m.tool_results.first()).expect("first result record");
         assert_eq!(first.content, STUB, "content collapses (the model's view)");

--- a/crates/cp-mod-todo/src/recap.rs
+++ b/crates/cp-mod-todo/src/recap.rs
@@ -107,7 +107,7 @@ fn collapse(content: &str, budget: usize) -> (String, usize) {
 
 #[cfg(test)]
 mod tests {
-    use super::{RECAP_CLOSE, RECAP_OPEN, STUB, collapse};
+    use super::{RECAP_CLOSE, RECAP_OPEN, STUB, collapse, strip_superseded};
 
     /// Build a recap block with `body` inside the sentinels.
     fn block(body: &str) -> String {
@@ -152,5 +152,81 @@ mod tests {
         let (out, n) = collapse(&content, 0);
         assert_eq!(n, 0);
         assert_eq!(out, content);
+    }
+
+    // ── End-to-end over a real `State` ───────────────────────────────────
+    //
+    // The `collapse` tests above pin the string surgery; these pin the part
+    // that actually ships: walking `state.messages`, keeping the LAST recap
+    // across messages, and leaving `display` untouched.
+
+    use cp_base::state::data::message::{Message, ToolResultRecord};
+    use cp_base::state::runtime::State;
+
+    /// A tool-result message carrying one record whose content is `content`.
+    fn result_msg(id: &str, content: String) -> Message {
+        let record = ToolResultRecord::new(format!("{id}_use"), content, false);
+        Message::new_tool_result(id.to_owned(), None, vec![record])
+    }
+
+    /// The content of every tool-result record, in conversation order.
+    fn contents(state: &State) -> Vec<String> {
+        state.messages.iter().flat_map(|m| m.tool_results.iter()).map(|r| r.content.clone()).collect()
+    }
+
+    #[test]
+    fn strips_every_recap_but_the_last_across_messages() {
+        let mut state = State::default();
+        state.messages.push(result_msg("R1", format!("Todo applied.\n\n{}", block("first"))));
+        state.messages.push(result_msg("R2", format!("Todo applied.\n\n{}", block("second"))));
+        state.messages.push(result_msg("R3", format!("Todo applied.\n\n{}", block("third"))));
+
+        assert_eq!(strip_superseded(&mut state), 2);
+
+        let got = contents(&state);
+        let mut seen = got.iter();
+        // The two older recaps collapse; their "Todo applied." survives.
+        assert_eq!(seen.next(), Some(&format!("Todo applied.\n\n{STUB}")));
+        assert_eq!(seen.next(), Some(&format!("Todo applied.\n\n{STUB}")));
+        // The most recent one is the live tree — untouched.
+        assert_eq!(seen.next(), Some(&format!("Todo applied.\n\n{}", block("third"))));
+    }
+
+    #[test]
+    fn single_recap_is_left_alone() {
+        let mut state = State::default();
+        let only = format!("Todo applied.\n\n{}", block("only"));
+        state.messages.push(result_msg("R1", only.clone()));
+
+        assert_eq!(strip_superseded(&mut state), 0);
+        assert_eq!(contents(&state).first(), Some(&only));
+    }
+
+    #[test]
+    fn repeated_passes_are_idempotent() {
+        let mut state = State::default();
+        state.messages.push(result_msg("R1", block("first")));
+        state.messages.push(result_msg("R2", block("second")));
+
+        assert_eq!(strip_superseded(&mut state), 1);
+        let after_first = contents(&state);
+        // Second pass finds a single surviving recap → nothing left to do.
+        assert_eq!(strip_superseded(&mut state), 0);
+        assert_eq!(contents(&state), after_first);
+    }
+
+    #[test]
+    fn display_is_never_rewritten() {
+        let mut state = State::default();
+        let full = block("first");
+        let record = ToolResultRecord::new("u1".to_owned(), full.clone(), false).display(Some(full.clone()));
+        state.messages.push(Message::new_tool_result("R1".to_owned(), None, vec![record]));
+        state.messages.push(result_msg("R2", block("second")));
+
+        assert_eq!(strip_superseded(&mut state), 1);
+
+        let first = state.messages.first().and_then(|m| m.tool_results.first()).expect("first result record");
+        assert_eq!(first.content, STUB, "content collapses (the model's view)");
+        assert_eq!(first.display.as_deref(), Some(full.as_str()), "display keeps the human's scrollback");
     }
 }

--- a/crates/cp-mod-todo/src/tree.rs
+++ b/crates/cp-mod-todo/src/tree.rs
@@ -13,14 +13,27 @@
 //!      no `in_progress` descendant (a parent that is in progress but has an
 //!      in-progress child does NOT count — the child is the real active front).
 //!
-//! [`result_annex`] bundles the two (tree, then the warning if any) — the single
-//! block appended/substituted at both call sites.
+//! [`result_annex`] bundles the two (tree, then the warning if any) into the
+//! single **tagged recap block** emitted at both call sites — the `Todo` tool's
+//! own result and the annex appended to an opted-in tool whose `task_id` flipped
+//! a task. Because there is exactly ONE producer, the block is always framed by
+//! [`RECAP_OPEN`] / [`RECAP_CLOSE`], which is what lets the conversation
+//! stripper find and collapse superseded recaps.
 
 use std::fmt::Write as _;
 
 use cp_base::state::runtime::State;
 
 use crate::types::{TodoItem, TodoState, TodoStatus};
+
+/// Opening sentinel of a task-recap block.
+///
+/// Comment syntax so it reads as machine framing rather than content, and so a
+/// task title can never collide with it. Paired with [`RECAP_CLOSE`]; the two
+/// delimit the byte range the conversation stripper collapses.
+pub const RECAP_OPEN: &str = "<!--TODO_RECAP-->";
+/// Closing sentinel of a task-recap block (see [`RECAP_OPEN`]).
+pub const RECAP_CLOSE: &str = "<!--/TODO_RECAP-->";
 
 /// The box-drawing prefixes, escaped as code points (clippy forbids non-ASCII
 /// string literals). `TEE`/`ELL` open a middle/last child line; `PIPE`/`GAP`
@@ -33,15 +46,24 @@ const PIPE: &str = "\u{2502}   "; // "│   "
 /// Continuation column under a last parent (blank).
 const GAP: &str = "    ";
 
-/// The tree + the optional multi-in-progress-leaf warning, ready to drop into a
-/// tool result. Empty string when the thread has no live tasks.
+/// The **complete, tagged task-recap block** for `thread_id`: header, tree, and
+/// the optional multi-in-progress-leaf warning, framed by [`RECAP_OPEN`] /
+/// [`RECAP_CLOSE`].
+///
+/// This is the single producer of a recap — both the `Todo` tool result and the
+/// `task_id` annex splice exactly this string, so the two can never drift and
+/// every recap in the conversation is uniformly delimited (and therefore
+/// strippable). Callers add their own framing *outside* the block: whatever they
+/// prepend survives stripping, everything inside does not.
 #[must_use]
 pub fn result_annex(state: &State, thread_id: &str) -> String {
     let tree = render(state, thread_id);
-    let mut out = if tree.is_empty() { "(no tasks on this thread)".to_owned() } else { tree };
+    let body = if tree.is_empty() { "(no tasks on this thread)" } else { tree.trim_end() };
+    let mut out = format!("{RECAP_OPEN}\nCurrent tasks:\n\n{body}");
     if let Some(warning) = in_progress_leaf_warning(state, thread_id) {
         let _w = write!(out, "\n\n{warning}");
     }
+    let _w = write!(out, "\n{RECAP_CLOSE}");
     out
 }
 

--- a/crates/cp-mod-todo/src/upsert.rs
+++ b/crates/cp-mod-todo/src/upsert.rs
@@ -1,0 +1,302 @@
+//! Structured task upsert — the `Todo` tool's core.
+//!
+//! The model hands in a list of items; each one either **updates** an existing
+//! task (it carries an `id`) or **creates** a new one (it does not). Parenthood
+//! is expressed *only* by physical nesting: an item's `children` are created
+//! under it, and a nested item may never carry an `id` — there is no
+//! `parent_id` anywhere in the surface.
+//!
+//! Two properties make this safe to drive blind:
+//!
+//!   * **Merge, never replace.** Tasks absent from the payload are left
+//!     untouched. Removal is an explicit `status: cancelled`, never an omission
+//!     — so a partial call can't silently wipe the roadmap.
+//!   * **Validate-then-apply.** [`upsert`] collects *every* problem before
+//!     mutating anything, so a bad call is a hard error that leaves the task
+//!     list exactly as it was (atomic, like the diff-based tool it replaces).
+
+use std::collections::HashSet;
+
+use cp_base::state::runtime::State;
+
+use crate::types::{TodoItem, TodoState, TodoStatus};
+
+// =============================================================================
+// Payload
+// =============================================================================
+
+/// One item of the `items` payload.
+///
+/// Every field is optional at parse time so validation (not deserialization)
+/// owns the error messages. `id` present = update that task; `id` absent =
+/// create. `children` are always creations parented to this item.
+#[derive(Debug, Default)]
+pub struct Item {
+    /// Existing task id to update. Absent means "create a new task".
+    pub id: Option<String>,
+    /// Task title. Required when creating; when updating, absent = untouched.
+    pub title: Option<String>,
+    /// Longer detail. Absent = untouched; present (even empty) = replace.
+    pub description: Option<String>,
+    /// Status wire string (`planned`/`in_progress`/`done`/`cancelled`).
+    pub status: Option<String>,
+    /// Nested items, created as children of this one. Creation-only — a child
+    /// carrying an `id` is a hard error.
+    pub children: Vec<Self>,
+}
+
+/// Parse the tool's `items` JSON array into [`Item`]s.
+///
+/// # Errors
+/// Returns `Err` when the value is not an array, or when any element (at any
+/// nesting depth) is not an object.
+pub fn parse_items(value: &serde_json::Value) -> Result<Vec<Item>, String> {
+    let arr = value.as_array().ok_or_else(|| "'items' must be an array".to_owned())?;
+    arr.iter().map(parse_item).collect()
+}
+
+/// Parse one payload element (must be a JSON object) into an [`Item`].
+fn parse_item(value: &serde_json::Value) -> Result<Item, String> {
+    let obj = value.as_object().ok_or_else(|| "each task item must be an object".to_owned())?;
+    let children = match obj.get("children") {
+        Some(nested) if !nested.is_null() => parse_items(nested)?,
+        _ => Vec::new(),
+    };
+    Ok(Item {
+        id: str_field(obj, "id"),
+        title: str_field(obj, "title"),
+        description: str_field(obj, "description"),
+        status: str_field(obj, "status"),
+        children,
+    })
+}
+
+/// Read an optional string field from a payload object.
+fn str_field(obj: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<String> {
+    obj.get(key).and_then(serde_json::Value::as_str).map(str::to_owned)
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+/// Apply `items` to `thread_id`'s task list, returning the ids of tasks created.
+///
+/// Validation runs over the whole payload first; on any problem nothing is
+/// mutated and the error names every issue at once.
+///
+/// # Errors
+/// Returns `Err` when a nested item carries an `id` (children are
+/// creation-only), an `id` does not resolve to a task of this thread, an `id`
+/// repeats within the call, a creation is missing its `title`, or a `status`
+/// string is not one of the four accepted values.
+pub fn upsert(state: &mut State, thread_id: &str, items: &[Item]) -> Result<Vec<String>, String> {
+    validate(state, thread_id, items)?;
+    let mut created: Vec<String> = Vec::new();
+    apply_group(state, items, Loc { thread_id, parent: None }, &mut created);
+    renumber_orders(state, thread_id);
+    Ok(created)
+}
+
+// =============================================================================
+// Validation — reject bad payloads BEFORE mutating (atomic apply)
+// =============================================================================
+
+/// Accumulator threaded through the validation walk.
+struct Ctx<'ctx> {
+    /// Live state, read-only during validation.
+    state: &'ctx State,
+    /// Thread whose tasks the payload targets.
+    thread_id: &'ctx str,
+    /// Ids already claimed by an earlier item in this same call.
+    seen: HashSet<String>,
+    /// Every problem found so far (reported together).
+    errors: Vec<String>,
+}
+
+/// Validate the whole payload, returning `Err` listing every problem at once.
+fn validate(state: &State, thread_id: &str, items: &[Item]) -> Result<(), String> {
+    let mut ctx = Ctx { state, thread_id, seen: HashSet::new(), errors: Vec::new() };
+    validate_group(&mut ctx, items, false);
+    if ctx.errors.is_empty() {
+        return Ok(());
+    }
+    Err(format!("{} problem(s) in this Todo call:\n  - {}", ctx.errors.len(), ctx.errors.join("\n  - ")))
+}
+
+/// Validate one sibling group; `nested` marks everything below the top level.
+fn validate_group(ctx: &mut Ctx<'_>, items: &[Item], nested: bool) {
+    for item in items {
+        validate_one(ctx, item, nested);
+        validate_group(ctx, &item.children, true);
+    }
+}
+
+/// Validate a single item's id/title/status triple.
+fn validate_one(ctx: &mut Ctx<'_>, item: &Item, nested: bool) {
+    match item.id.as_deref() {
+        Some(id) if nested => ctx.errors.push(format!(
+            "nested item `{id}`: children are creation-only \u{2014} drop its `id` (nesting alone sets the parent)"
+        )),
+        Some(id) => validate_existing(ctx, id),
+        None => validate_create(ctx, item),
+    }
+    validate_status(ctx, item);
+}
+
+/// An `id` must resolve to a task of this thread, and appear only once.
+fn validate_existing(ctx: &mut Ctx<'_>, id: &str) {
+    let exists = TodoState::get(ctx.state).todos.iter().any(|t| t.id == id && t.thread_id == ctx.thread_id);
+    if !exists {
+        ctx.errors.push(format!(
+            "item id `{id}` does not exist on this thread \u{2014} ids are backend-assigned; omit `id` to create"
+        ));
+        return;
+    }
+    if !ctx.seen.insert(id.to_owned()) {
+        ctx.errors.push(format!("item id `{id}` appears more than once in this call"));
+    }
+}
+
+/// A creation (no `id`) needs a non-empty `title`.
+fn validate_create(ctx: &mut Ctx<'_>, item: &Item) {
+    if item.title.as_deref().map(str::trim).is_none_or(str::is_empty) {
+        ctx.errors.push("a new item (no `id`) is missing a non-empty `title`".to_owned());
+    }
+}
+
+/// A provided `status` must be one of the four accepted wire values.
+fn validate_status(ctx: &mut Ctx<'_>, item: &Item) {
+    let Some(raw) = item.status.as_deref().map(str::trim).filter(|s| !s.is_empty()) else {
+        return;
+    };
+    if parse_status(raw).is_none() {
+        ctx.errors.push(format!("invalid status `{raw}` \u{2014} use one of: planned, in_progress, done, cancelled"));
+    }
+}
+
+// =============================================================================
+// Apply
+// =============================================================================
+
+/// A sibling group's location: owning thread + parent id (`None` = root group).
+#[derive(Clone, Copy)]
+struct Loc<'loc> {
+    /// Owning thread id.
+    thread_id: &'loc str,
+    /// Parent task id, or `None` for the root group.
+    parent: Option<&'loc str>,
+}
+
+/// Apply one sibling group, then recurse into each item's children.
+fn apply_group(state: &mut State, items: &[Item], loc: Loc<'_>, created: &mut Vec<String>) {
+    for item in items {
+        let Some(id) = apply_one(state, item, loc, created) else {
+            continue;
+        };
+        apply_group(state, &item.children, Loc { thread_id: loc.thread_id, parent: Some(&id) }, created);
+    }
+}
+
+/// Update an identified task in place, or create a new one. Returns its id so
+/// children can attach to it.
+fn apply_one(state: &mut State, item: &Item, loc: Loc<'_>, created: &mut Vec<String>) -> Option<String> {
+    if let Some(id) = item.id.as_deref() {
+        patch(state, id, item);
+        return Some(id.to_owned());
+    }
+    let id = create(state, item, loc)?;
+    created.push(id.clone());
+    Some(id)
+}
+
+/// Patch the provided fields of an existing task. Absent fields are untouched,
+/// and neither parent nor sibling order ever moves (upsert never reparents).
+fn patch(state: &mut State, id: &str, item: &Item) {
+    let status = item.status.as_deref().and_then(parse_status);
+    let ts = TodoState::get_mut(state);
+    let Some(target) = ts.todos.iter_mut().find(|t| t.id == id) else {
+        return;
+    };
+    if let Some(title) = item.title.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
+        title.clone_into(&mut target.name);
+    }
+    if let Some(desc) = item.description.as_deref() {
+        desc.clone_into(&mut target.description);
+    }
+    if let Some(s) = status {
+        target.status = s;
+    }
+}
+
+/// Create a task at the end of `loc`'s sibling group. Returns its fresh id.
+fn create(state: &mut State, item: &Item, loc: Loc<'_>) -> Option<String> {
+    let name = item.title.as_deref().map(str::trim).filter(|t| !t.is_empty())?.to_owned();
+    let status = item.status.as_deref().and_then(parse_status).unwrap_or(TodoStatus::Planned);
+    let description = item.description.clone().unwrap_or_default();
+    let order = next_order(state, loc);
+    let ts = TodoState::get_mut(state);
+    let id = format!("X{}", ts.next_todo_id);
+    ts.next_todo_id = ts.next_todo_id.saturating_add(1);
+    ts.todos.push(TodoItem {
+        id: id.clone(),
+        thread_id: loc.thread_id.to_owned(),
+        parent_id: loc.parent.map(str::to_owned),
+        name,
+        description,
+        status,
+        order,
+    });
+    Some(id)
+}
+
+/// The order a new task takes at the end of `loc`'s sibling group.
+fn next_order(state: &State, loc: Loc<'_>) -> i32 {
+    TodoState::get(state)
+        .todos
+        .iter()
+        .filter(|t| t.thread_id == loc.thread_id && t.parent_id.as_deref() == loc.parent)
+        .map(|t| t.order)
+        .max()
+        .map_or(0i32, |m| m.saturating_add(1))
+}
+
+// =============================================================================
+// Order maintenance
+// =============================================================================
+
+/// One row of the renumber snapshot: (id, `parent_id`, current order, cancelled).
+type OrderRow = (String, Option<String>, i32, bool);
+
+/// Renumber `order` densely (0..n) within every parent group of `thread_id`,
+/// cancelled tasks placed last — the single source of truth both the canonical
+/// render and the wire projection sort by.
+pub fn renumber_orders(state: &mut State, thread_id: &str) {
+    let ts = TodoState::get_mut(state);
+    // Snapshot the sort inputs so the borrow ends before we mutate each order.
+    let mut rows: Vec<OrderRow> = ts
+        .todos
+        .iter()
+        .filter(|t| t.thread_id == thread_id)
+        .map(|t| (t.id.clone(), t.parent_id.clone(), t.order, t.status == TodoStatus::Cancelled))
+        .collect();
+    // Group by parent, then cancelled-last, then existing order, then id.
+    rows.sort_by(|a, b| (&a.1, a.3, a.2, &a.0).cmp(&(&b.1, b.3, b.2, &b.0)));
+    let mut current_parent: Option<Option<String>> = None;
+    let mut next = 0i32;
+    for (id, parent, _, _) in rows {
+        if current_parent.as_ref() != Some(&parent) {
+            current_parent = Some(parent.clone());
+            next = 0i32;
+        }
+        if let Some(item) = ts.todos.iter_mut().find(|t| t.id == id) {
+            item.order = next;
+        }
+        next = next.saturating_add(1);
+    }
+}
+
+/// Parse a status string, or `None` when unrecognised.
+fn parse_status(raw: &str) -> Option<TodoStatus> {
+    raw.trim().parse().ok()
+}

--- a/crates/cp-mod-todo/src/yaml.rs
+++ b/crates/cp-mod-todo/src/yaml.rs
@@ -1,61 +1,21 @@
-//! Virtual-YAML projection of the thread-owned task tree (YAML-diff rework).
+//! Canonical YAML render of a thread's task tree.
 //!
-//! The `Todo` tool no longer takes a structured forest; it takes a list of
-//! `{prev, new}` text diffs applied to a **virtual YAML file** that exists only
-//! at apply time and in the panel. This module owns the three pieces that make
-//! that work:
+//! A **read-only projection**: [`render`] turns a thread's tasks into a
+//! byte-stable YAML document with deterministic field order, 2-space indent and
+//! `description: |` block scalars. It feeds the Todo panel — the human- and
+//! model-facing view of the tree.
 //!
-//!   1. [`render`] — the **canonical, byte-stable** YAML of a thread's tree
-//!      (feeds both the Todo panel and the tool's echo). Deterministic field
-//!      order, 2-space indent, `description: |` block scalars — so the `prev`
-//!      strings the model copies always match at apply time.
-//!   2. [`apply_diffs`] — apply the ordered `{prev, new}` edits to the rendered
-//!      buffer (search/replace, unique-`prev` like the `Edit` tool), then parse
-//!      and reconcile the result, then re-render and return the fresh canonical
-//!      YAML.
-//!   3. `reconcile` (private) — fold a parsed tree back into [`TodoState`]
-//!      **by id**: existing id → patch in place; absent id → create; a
-//!      previously-present id now gone from the YAML → **soft-cancel** (sorted
-//!      last in its parent group). `order` is reconstructed from sibling
-//!      position here — it is never written in the YAML.
+//! Editing lives entirely in [`crate::upsert`] (structured, nested upsert): this
+//! module never mutates state and never parses YAML back.
+//!
+//! The item shape is `- {id}: {status}` (the id is the mapping KEY, its value
+//! the status) with `title` / `description` / `children` as sibling keys.
 
-use std::collections::HashSet;
 use std::fmt::Write as _;
 
 use cp_base::state::runtime::State;
 
-use crate::types::{TodoItem, TodoState, TodoStatus};
-
-// =============================================================================
-// Parsed YAML node
-// =============================================================================
-
-/// One node of the edited virtual YAML, populated by [`node_from_value`].
-///
-/// Every field is optional so a malformed-but-parseable node still loads: a
-/// missing `title` on a *create* is the one hard error (caught in `reconcile`);
-/// a missing `id` simply means "create". In the id-as-key shape the item's first
-/// line is `- {id}: {status}` — the id is the mapping KEY and its value is the
-/// status — so `title`/`description`/`children` are its sibling keys. The
-/// canonical re-render is the safety net that surfaces any mis-nest to the model
-/// on the next turn.
-#[derive(Debug, Default)]
-struct YamlNode {
-    /// Item id (`X{n}`); absent means "create a new item".
-    id: Option<String>,
-    /// Task title (required when creating).
-    title: Option<String>,
-    /// Status wire string (`planned`/`in_progress`/`done`/`cancelled`).
-    status: Option<String>,
-    /// Longer description (block scalar in the canonical render).
-    description: Option<String>,
-    /// Nested child nodes (the `children:` sub-list).
-    children: Vec<Self>,
-}
-
-// =============================================================================
-// Canonical render
-// =============================================================================
+use crate::types::{TodoItem, TodoStatus};
 
 /// The canonical YAML for `thread_id`'s task tree.
 ///
@@ -64,7 +24,7 @@ struct YamlNode {
 /// (soft-delete convention).
 #[must_use]
 pub fn render(state: &State, thread_id: &str) -> String {
-    let ts = TodoState::get(state);
+    let ts = crate::types::TodoState::get(state);
     let items: Vec<&TodoItem> = ts.todos.iter().filter(|t| t.thread_id == thread_id).collect();
     let mut out = String::new();
     render_group(&items, None, 0, &mut out);
@@ -91,9 +51,9 @@ fn render_group(items: &[&TodoItem], parent: Option<&str>, depth: usize, out: &m
 /// then recurse into its children one level deeper.
 fn render_item(items: &[&TodoItem], item: &TodoItem, depth: usize, out: &mut String) {
     let indent = "  ".repeat(depth);
-    // `- {id}: {status}` opens the list entry — the id is the mapping KEY, so a
-    // status flip is a tiny inline edit (`X106: in progress` → `X106: done`)
-    // that needs no surrounding-line match. Sibling keys align under it.
+    // `- {id}: {status}` opens the list entry — the id is the mapping KEY, so
+    // the panel reads as a compact `X106: in_progress` line. Sibling keys align
+    // under it.
     _ = writeln!(out, "{indent}- {}: {}", item.id, status_wire(item.status));
     _ = writeln!(out, "{indent}  title: {}", scalar(&item.name));
     if !item.description.is_empty() {
@@ -109,7 +69,8 @@ fn render_item(items: &[&TodoItem], item: &TodoItem, depth: usize, out: &mut Str
     }
 }
 
-/// The canonical wire string for a status (matches the parser's accepted forms).
+/// The canonical wire string for a status (matches the `Todo` tool's accepted
+/// `status` values).
 const fn status_wire(status: TodoStatus) -> &'static str {
     match status {
         TodoStatus::Planned => "planned",
@@ -124,352 +85,11 @@ const fn status_wire(status: TodoStatus) -> &'static str {
 /// Titles are single-line; we double-quote when the value could otherwise be
 /// mis-parsed (leading/trailing space, or a character YAML treats specially in
 /// plain scalars), escaping `\` and `"`. A plain-safe value is emitted bare so
-/// the common case stays clean and diff-friendly.
+/// the common case stays clean and readable.
 fn scalar(s: &str) -> String {
     let needs_quote = s.is_empty()
         || s != s.trim()
         || s.contains(['"', '\'', ':', '#', '\n', '\t'])
         || s.starts_with(['-', '?', '&', '*', '!', '|', '>', '%', '@', '`', '[', ']', '{', '}', ',']);
     if needs_quote { format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\"")) } else { s.to_owned() }
-}
-
-// =============================================================================
-// apply_diffs — the tool entry point
-// =============================================================================
-
-/// Apply the ordered `{prev, new}` text diffs to `thread_id`'s canonical YAML,
-/// reconcile the result into [`TodoState`], and return the **fresh** canonical
-/// YAML.
-///
-/// Each diff is a search/replace on the working buffer (applied in order, so a
-/// later diff sees earlier results). `prev` must match **exactly once** (like
-/// the `Edit` tool) — zero or multiple matches is an error naming the offending
-/// diff. An **empty `prev` appends** `new` at the end of the buffer (handy for
-/// adding a root item). A YAML parse failure of the final buffer is an error
-/// (nothing is committed). On success the thread's tasks are updated and the
-/// re-rendered canonical YAML is returned.
-///
-/// # Errors
-/// Returns `Err` with a human-readable message when a `prev` is not found /
-/// ambiguous, the resulting buffer is not valid YAML, or the edited tree fails
-/// validation (an unresolved `id:`, a create missing its `title:`, or an
-/// unparseable `status:`). State is left untouched on any error.
-pub fn apply_diffs(state: &mut State, thread_id: &str, diffs: &[(String, String)]) -> Result<String, String> {
-    let mut buffer = render(state, thread_id);
-    for (idx, diff) in diffs.iter().enumerate() {
-        apply_one_diff(&mut buffer, diff.0.as_str(), diff.1.as_str(), idx)?;
-    }
-    // A wholly empty (or whitespace-only) buffer means "clear the list" — every
-    // item was deleted. `serde_yaml` rejects an empty document for a `Vec`, so
-    // treat it as the empty tree rather than surfacing a spurious parse error
-    // (otherwise the list could never be emptied by deleting all its lines).
-    let nodes: Vec<YamlNode> = if buffer.trim().is_empty() { Vec::new() } else { parse_nodes(&buffer)? };
-    // Validate the parsed tree BEFORE mutating anything, so a bad edit (an
-    // unresolved `id:`, a create missing its `title:`, an unparseable `status:`)
-    // is a hard error that leaves the tasks untouched — never a silent
-    // mis-apply that cancels real children or drops an invalid status.
-    validate_nodes(state, thread_id, &nodes)?;
-    reconcile(state, thread_id, &nodes);
-    Ok(render(state, thread_id))
-}
-
-/// Apply one search/replace diff to `buffer`. Empty `prev` appends `new`.
-fn apply_one_diff(buffer: &mut String, prev: &str, new: &str, idx: usize) -> Result<(), String> {
-    if prev.is_empty() {
-        if !buffer.is_empty() && !buffer.ends_with('\n') {
-            buffer.push('\n');
-        }
-        buffer.push_str(new);
-        return Ok(());
-    }
-    let count = buffer.matches(prev).count();
-    match count {
-        0 => Err(format!("diff #{}: 'prev' not found in the current YAML", idx.saturating_add(1))),
-        1 => {
-            *buffer = buffer.replacen(prev, new, 1);
-            Ok(())
-        }
-        n => Err(format!(
-            "diff #{}: 'prev' matches {n} places — make it unique (include the item's `id:` line)",
-            idx.saturating_add(1)
-        )),
-    }
-}
-
-// =============================================================================
-// parse — the id-as-key shape → YamlNode tree
-// =============================================================================
-
-/// Parse the edited buffer into the internal node tree.
-///
-/// The shape is a sequence of item mappings whose first line is `- {id}: {status}`
-/// — the id is the mapping KEY, its value the status — plus optional `title`,
-/// `description`, and a nested `children:` sequence. An item with **no** id key
-/// is a create (status from an optional `status:` key, else default). We parse
-/// into a generic [`serde_yaml::Value`] and hand-walk it, so the dynamic id key
-/// is read positionally rather than via a fixed struct field.
-fn parse_nodes(buffer: &str) -> Result<Vec<YamlNode>, String> {
-    let value: serde_yaml::Value =
-        serde_yaml::from_str(buffer).map_err(|e| format!("resulting YAML is invalid: {e}"))?;
-    nodes_from_value(&value)
-}
-
-/// A YAML value that should be a sequence-of-item-mappings → nodes (null = empty).
-fn nodes_from_value(value: &serde_yaml::Value) -> Result<Vec<YamlNode>, String> {
-    if value.is_null() {
-        return Ok(Vec::new());
-    }
-    let seq = value.as_sequence().ok_or_else(|| "expected a YAML list of task items".to_owned())?;
-    seq.iter().map(node_from_value).collect()
-}
-
-/// Parse one item value (must be a mapping) into a [`YamlNode`].
-///
-/// Reserved keys (`title`/`description`/`status`/`children`) map to their field;
-/// any *other* string key is the item **id** and its value is the status. A
-/// second such key is a hard error (ambiguous id).
-fn node_from_value(value: &serde_yaml::Value) -> Result<YamlNode, String> {
-    let map = value.as_mapping().ok_or_else(|| "each task item must be a mapping".to_owned())?;
-    let mut node = YamlNode::default();
-    for (raw_key, val) in map {
-        let key = raw_key.as_str().ok_or_else(|| "task item keys must be strings".to_owned())?;
-        match key {
-            "title" => node.title = val.as_str().map(str::to_owned),
-            "description" => node.description = val.as_str().map(str::to_owned),
-            "status" => node.status = val.as_str().map(str::to_owned),
-            "children" => node.children = nodes_from_value(val)?,
-            id => set_id_status(&mut node, id, val)?,
-        }
-    }
-    Ok(node)
-}
-
-/// Record the item's id (the mapping key) and its status (the key's value).
-/// The id-key value wins over any explicit `status:` key when non-empty.
-fn set_id_status(node: &mut YamlNode, id: &str, val: &serde_yaml::Value) -> Result<(), String> {
-    if let Some(existing) = node.id.as_deref() {
-        return Err(format!("task item has more than one id key (`{existing}` and `{id}`)"));
-    }
-    node.id = Some(id.to_owned());
-    if let Some(status) = val.as_str().map(str::trim).filter(|s| !s.is_empty()) {
-        node.status = Some(status.to_owned());
-    }
-    Ok(())
-}
-
-// =============================================================================
-// validation — reject bad edits BEFORE mutating (atomic apply)
-// =============================================================================
-
-/// Validate the parsed `nodes` tree against `thread_id`'s current tasks,
-/// returning `Err` listing every problem (so the model can fix them all at
-/// once) or `Ok(())` when the edit is safe to apply.
-///
-/// Three classes of problem are rejected — each of which would otherwise cause
-/// a silent, surprising mutation:
-///   * an `id:` that does not resolve to an existing item of this thread (ids
-///     are backend-assigned; a stale/typo'd id must never be treated as a
-///     create, and — the dangerous case — must never let its real children be
-///     silently soft-cancelled);
-///   * a create (no `id:`) missing a non-empty `title:`;
-///   * a `status:` string that is not one of the accepted values.
-fn validate_nodes(state: &State, thread_id: &str, nodes: &[YamlNode]) -> Result<(), String> {
-    let mut errors: Vec<String> = Vec::new();
-    validate_group(state, thread_id, nodes, &mut errors);
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(format!("{} problem(s) in the edited task YAML:\n  - {}", errors.len(), errors.join("\n  - ")))
-    }
-}
-
-/// Recursively validate one sibling group, pushing any problems onto `errors`.
-fn validate_group(state: &State, thread_id: &str, nodes: &[YamlNode], errors: &mut Vec<String>) {
-    for node in nodes {
-        match node.id.as_deref() {
-            Some(id) => {
-                let exists = TodoState::get(state).todos.iter().any(|t| t.id == id && t.thread_id == thread_id);
-                if !exists {
-                    errors.push(format!(
-                        "item id `{id}` does not exist on this thread — ids are backend-assigned; omit the `id:` line to create a new item"
-                    ));
-                }
-            }
-            None => {
-                if node.title.as_deref().map(str::trim).is_none_or(str::is_empty) {
-                    errors.push("a new item (no `id:`) is missing a non-empty `title:`".to_owned());
-                }
-            }
-        }
-        if let Some(raw) = node.status.as_deref()
-            && !raw.trim().is_empty()
-            && parse_status(raw).is_none()
-        {
-            errors.push(format!("invalid status `{}` — use one of: planned, in_progress, done, cancelled", raw.trim()));
-        }
-        validate_group(state, thread_id, &node.children, errors);
-    }
-}
-
-// =============================================================================
-// reconcile — fold parsed tree back into TodoState by id
-// =============================================================================
-
-/// A sibling group's location: owning thread + parent id (`None` = root group).
-#[derive(Clone, Copy)]
-struct Loc<'loc> {
-    /// Owning thread id.
-    thread_id: &'loc str,
-    /// Parent item id, or `None` for the root group.
-    parent: Option<&'loc str>,
-}
-
-/// One node's slot: its group location plus its positional order among siblings.
-#[derive(Clone, Copy)]
-struct Slot<'slot> {
-    /// The group this node belongs to.
-    loc: Loc<'slot>,
-    /// Zero-based index among its siblings in the YAML (its `order`).
-    order: i32,
-}
-
-/// Accumulator threaded through the reconcile walk.
-struct ReconcileCtx {
-    /// Ids present in the incoming YAML that resolved to an existing item
-    /// (updated) or were freshly created — everything NOT here is soft-cancelled.
-    seen: HashSet<String>,
-}
-
-/// Fold the parsed `nodes` tree back into `thread_id`'s tasks **by id**.
-///
-/// Existing id → patch (title/status/description/parent/order); absent id →
-/// create (next `X{n}`); a previously-present id now missing from the YAML →
-/// soft-cancel. `order` is the node's index among its siblings in the YAML.
-fn reconcile(state: &mut State, thread_id: &str, nodes: &[YamlNode]) {
-    let mut ctx = ReconcileCtx { seen: HashSet::new() };
-    reconcile_group(state, nodes, Loc { thread_id, parent: None }, &mut ctx);
-    cancel_unseen(state, thread_id, &ctx.seen);
-    renumber_orders(state, thread_id);
-}
-
-/// Reconcile one sibling group (children of `loc.parent`), assigning each node
-/// its positional `order`, then recursing into its own children.
-fn reconcile_group(state: &mut State, nodes: &[YamlNode], loc: Loc<'_>, ctx: &mut ReconcileCtx) {
-    for (idx, node) in nodes.iter().enumerate() {
-        let order = i32::try_from(idx).unwrap_or(i32::MAX);
-        let resolved = reconcile_node(state, node, Slot { loc, order }, ctx);
-        if let Some(id) = resolved {
-            reconcile_group(state, &node.children, Loc { thread_id: loc.thread_id, parent: Some(&id) }, ctx);
-        }
-    }
-}
-
-/// Reconcile one node: update an existing id in place, or create a new item.
-/// Returns the item's id (so its children can attach), or `None` on a bad node.
-fn reconcile_node(state: &mut State, node: &YamlNode, slot: Slot<'_>, ctx: &mut ReconcileCtx) -> Option<String> {
-    let thread_id = slot.loc.thread_id;
-    let existing_id = node
-        .id
-        .as_deref()
-        .filter(|id| TodoState::get(state).todos.iter().any(|t| &t.id == id && t.thread_id == thread_id));
-
-    if let Some(id) = existing_id {
-        let owned_id = id.to_owned();
-        patch_item(state, &owned_id, node, slot);
-        let _inserted = ctx.seen.insert(owned_id.clone());
-        return Some(owned_id);
-    }
-
-    // Create: title is required (an id that didn't resolve falls through here).
-    let name = node.title.as_deref().map(str::trim).filter(|t| !t.is_empty())?;
-    let status = node.status.as_deref().and_then(parse_status);
-    let ts = TodoState::get_mut(state);
-    let id = format!("X{}", ts.next_todo_id);
-    ts.next_todo_id = ts.next_todo_id.saturating_add(1);
-    ts.todos.push(TodoItem {
-        id: id.clone(),
-        thread_id: thread_id.to_owned(),
-        parent_id: slot.loc.parent.map(str::to_owned),
-        name: name.to_owned(),
-        description: node.description.clone().unwrap_or_default(),
-        status: status.unwrap_or(TodoStatus::Planned),
-        order: slot.order,
-    });
-    let _inserted = ctx.seen.insert(id.clone());
-    Some(id)
-}
-
-/// Apply an in-place field patch to an existing item (title/status/description/
-/// parent/order). Status is derived from the node here.
-fn patch_item(state: &mut State, id: &str, node: &YamlNode, slot: Slot<'_>) {
-    let status = node.status.as_deref().and_then(parse_status);
-    let ts = TodoState::get_mut(state);
-    let Some(item) = ts.todos.iter_mut().find(|t| t.id == id) else {
-        return;
-    };
-    if let Some(title) = node.title.as_deref().map(str::trim).filter(|t| !t.is_empty()) {
-        title.clone_into(&mut item.name);
-    }
-    // Description is authoritative from the YAML: an omitted key clears it (the
-    // canonical render always emits a non-empty description, so omission is a
-    // deliberate delete), a present block replaces it.
-    item.description = node.description.clone().unwrap_or_default();
-    item.parent_id = slot.loc.parent.map(str::to_owned);
-    item.order = slot.order;
-    if let Some(s) = status {
-        item.status = s;
-    }
-}
-
-/// Soft-cancel every non-cancelled item of `thread_id` whose id is absent from
-/// `seen` (removed from the edited YAML). Cancelled items sort last in their
-/// group via [`renumber_orders`].
-fn cancel_unseen(state: &mut State, thread_id: &str, seen: &HashSet<String>) {
-    let ts = TodoState::get_mut(state);
-    for item in &mut ts.todos {
-        if item.thread_id == thread_id && item.status != TodoStatus::Cancelled && !seen.contains(&item.id) {
-            item.status = TodoStatus::Cancelled;
-        }
-    }
-}
-
-/// One row of the renumber snapshot: (id, `parent_id`, current order, cancelled).
-type OrderRow = (String, Option<String>, i32, bool);
-
-/// Renumber `order` densely (0..n) within every parent group of `thread_id`,
-/// cancelled items placed last — the single source of truth both [`render`] and
-/// the wire projection sort by.
-fn renumber_orders(state: &mut State, thread_id: &str) {
-    let ts = TodoState::get_mut(state);
-    // Snapshot the sort inputs (id, parent, order, cancelled) so the borrow ends
-    // before we mutate each item's order.
-    let mut rows: Vec<OrderRow> = ts
-        .todos
-        .iter()
-        .filter(|t| t.thread_id == thread_id)
-        .map(|t| (t.id.clone(), t.parent_id.clone(), t.order, t.status == TodoStatus::Cancelled))
-        .collect();
-    rows.sort_by(|a, b| {
-        // group by parent, then cancelled-last, then existing order, then id.
-        (&a.1, a.3, a.2, &a.0).cmp(&(&b.1, b.3, b.2, &b.0))
-    });
-    // Walk groups in the sorted order, assigning 0..n per parent.
-    let mut current_parent: Option<Option<String>> = None;
-    let mut next = 0i32;
-    for (id, parent, _, _) in rows {
-        if current_parent.as_ref() != Some(&parent) {
-            current_parent = Some(parent.clone());
-            next = 0i32;
-        }
-        if let Some(item) = ts.todos.iter_mut().find(|t| t.id == id) {
-            item.order = next;
-        }
-        next = next.saturating_add(1);
-    }
-}
-
-/// Parse a status string (canonical wire value or an ergonomics alias), or
-/// `None` for an unrecognised value (the item keeps its prior status).
-fn parse_status(raw: &str) -> Option<TodoStatus> {
-    raw.trim().parse().ok()
 }

--- a/src/app/run/tools/checks.rs
+++ b/src/app/run/tools/checks.rs
@@ -56,6 +56,31 @@ pub(crate) fn check_deferred_sleep(app: &mut App, tx: &Sender<StreamEvent>) {
 // `cp-mod-threads` (`FocusState`) and `cp-mod-todo` (`TodoState`), which never
 // import each other (design §8 dependency-injection rule).
 
+/// Collapse every superseded task recap in the live conversation, keeping only
+/// the most recent one (the actual work lives in `cp_mod_todo::recap`, beside
+/// the block's producer).
+///
+/// Gated on two conditions, both load-bearing:
+///
+///   * **Queue idle.** While the queue intercepts, a batch is still forming and
+///     the conversation is mid-construction — leave it alone.
+///   * **Tempo already broken.** Rewriting old messages mutates the conversation
+///     *prefix*, invalidating the LLM prompt cache from the earliest edited
+///     message onward. On a tempo-preserving tick that cost would be gratuitous;
+///     on a tempo-breaking tick the cache is dropped anyway, so the strip rides
+///     along for free. Do not relax this without understanding the trade.
+///
+/// The caller runs this *after* the tempo break so `state.tempo` is final.
+pub(crate) fn strip_superseded_recaps(app: &mut App) {
+    if cp_mod_queue::types::QueueState::get(&app.state).active || app.state.tempo {
+        return;
+    }
+    let stripped = cp_mod_todo::recap::strip_superseded(&mut app.state);
+    if stripped > 0 {
+        log::debug!("todo recap: collapsed {stripped} superseded task recap(s)");
+    }
+}
+
 /// Push the focused thread id onto `TodoState` so the Todo panel scopes to it.
 ///
 /// When focus changed, the panel's previous content is stale (it pointed at the

--- a/src/app/run/tools/checks.rs
+++ b/src/app/run/tools/checks.rs
@@ -71,14 +71,27 @@ pub(crate) fn check_deferred_sleep(app: &mut App, tx: &Sender<StreamEvent>) {
 ///     along for free. Do not relax this without understanding the trade.
 ///
 /// The caller runs this *after* the tempo break so `state.tempo` is final.
+///
+/// Every touched message is re-persisted: the strip edits the conversation's
+/// single source of truth, so skipping the save would fork it into a stripped
+/// in-memory copy and a full-recap on-disk one, and every reload would redo the
+/// same work. Persisting makes the collapse happen exactly once per recap.
 pub(crate) fn strip_superseded_recaps(app: &mut App) {
     if cp_mod_queue::types::QueueState::get(&app.state).active || app.state.tempo {
         return;
     }
-    let stripped = cp_mod_todo::recap::strip_superseded(&mut app.state);
-    if stripped > 0 {
-        log::debug!("todo recap: collapsed {stripped} superseded task recap(s)");
+    let touched = cp_mod_todo::recap::strip_superseded(&mut app.state);
+    if touched.is_empty() {
+        return;
     }
+    // Clone first so the immutable borrow of `messages` ends before the save
+    // (which needs `&App`). Indices are valid — nothing mutated the vec since.
+    let saved: Vec<crate::state::Message> =
+        touched.iter().filter_map(|&idx| app.state.messages.get(idx).cloned()).collect();
+    for msg in &saved {
+        app.save_message_async(msg);
+    }
+    log::debug!("todo recap: collapsed superseded recap(s) in {} message(s)", saved.len());
 }
 
 /// Push the focused thread id onto `TodoState` so the Todo panel scopes to it.

--- a/src/app/run/tools/cleanup.rs
+++ b/src/app/run/tools/cleanup.rs
@@ -185,7 +185,14 @@ fn force_resolve_stragglers(tool_results: &mut [crate::infra::tools::ToolResult]
             "Console wait result unavailable (watcher expired or was interrupted)".clone_into(&mut tr.content);
         } else if tr.content.starts_with(CONSOLE_WAIT_BLOCKING_SENTINEL) {
             let after = &tr.content.get(CONSOLE_WAIT_BLOCKING_SENTINEL.len()..).unwrap_or("");
-            tr.content = format!("Callback result unavailable (timeout). Original: {after}");
+            if after.starts_with("cb_block_") {
+                tr.content = format!("Callback result unavailable (timeout). Original: {after}");
+            } else {
+                // Console/async-tool sentinel with appended pre-flight text — not a
+                // callback. The appended text is typically pre-flight warnings
+                // (e.g. "\nWarning: Task 'X525' belongs to thread T92…").
+                tr.content = format!("Blocking tool result unavailable (watcher expired or was interrupted).{after}");
+            }
         } else {
             // Not a sentinel — already a real result, leave untouched.
         }
@@ -204,7 +211,17 @@ fn replace_blocking_sentinels(
         if tr.content == CONSOLE_WAIT_BLOCKING_SENTINEL {
             apply_console_wait_result(tr, merged_blocking);
         } else if tr.content.starts_with(CONSOLE_WAIT_BLOCKING_SENTINEL) {
-            apply_callback_result(tr, merged_blocking);
+            let after = tr.content.get(CONSOLE_WAIT_BLOCKING_SENTINEL.len()..).unwrap_or("");
+            if after.starts_with("cb_block_") {
+                apply_callback_result(tr, merged_blocking);
+            } else {
+                // Console/async-tool sentinel with appended pre-flight warnings —
+                // not a callback. Resolve via the console-wait path and re-append
+                // the warnings so they survive.
+                let appended = after.to_owned();
+                apply_console_wait_result(tr, merged_blocking);
+                tr.content.push_str(&appended);
+            }
         } else {
             // Non-sentinel result — nothing to replace.
         }

--- a/src/app/run/tools/pipeline.rs
+++ b/src/app/run/tools/pipeline.rs
@@ -359,6 +359,8 @@ pub(crate) fn handle_tool_execution(app: &mut App, tx: &Sender<StreamEvent>) {
     maybe_trigger_reverie(app, &tool_results);
     super::callbacks::fire_edit_callbacks(app, &tools, &mut tool_results);
     apply_tempo_break(app, &tool_results);
+    // Runs after the tempo break so it observes this tick's FINAL tempo.
+    super::checks::strip_superseded_recaps(app);
 
     // Sync the Todo panel's focus filter to the focused thread (forces a fresh
     // Todo panel on focus change), then evaluate the fire-once hygiene nudge.

--- a/src/modules/questions/mod.rs
+++ b/src/modules/questions/mod.rs
@@ -16,15 +16,23 @@ static CORE_TOOL_TEXTS: std::sync::LazyLock<ToolTexts> =
 /// Module that provides the Think reasoning tool.
 pub(crate) struct QuestionsModule;
 
-/// The `Todo` tool's `diffs` item type: a `{prev, new}` search/replace edit
-/// applied to the virtual task YAML (the same paradigm as the `Edit` tool's
-/// `old_string`/`new_string`).
-fn todo_diff_object() -> ParamType {
+/// The `Todo` tool's `items` element type: one task to create or update, with
+/// optional nested `children` (creation-only — nesting alone sets the parent).
+///
+/// `children` is declared as a free-form array rather than a recursive
+/// `ParamType::Object` because the schema language has no self-reference; the
+/// executor parses it recursively and the tool description documents the shape.
+fn todo_item_object() -> ParamType {
     ParamType::Object(vec![
-        ToolParam::new("prev", ParamType::String).desc(
-            "Exact text to find in the current task YAML (must match exactly once; empty appends 'new' at the end). Prefer a tiny id-anchored anchor like 'X41: in_progress'.",
+        ToolParam::new("id", ParamType::String)
+            .desc("Existing task id to UPDATE (e.g. 'X41'). Omit to CREATE. Never allowed on a nested child."),
+        ToolParam::new("title", ParamType::String).desc("Task title. Required when creating; omit to leave untouched."),
+        ToolParam::new("description", ParamType::String).desc("Longer detail. Omit to leave untouched."),
+        ToolParam::new("status", ParamType::String)
+            .desc("One of: planned, in_progress, done, cancelled. Defaults to planned on create."),
+        ToolParam::new("children", ParamType::Array(Box::new(ParamType::Object(vec![])))).desc(
+            "Nested tasks CREATED under this one. Same fields as a parent item, minus `id` (nesting sets the parent).",
         ),
-        ToolParam::new("new", ParamType::String).desc("Replacement text"),
     ])
 }
 
@@ -62,9 +70,9 @@ impl Module for QuestionsModule {
                 .param("task_context", ParamType::String, false)
                 .build(),
             ToolDefinition::from_yaml("Todo", core_t)
-                .short_desc("Edit the task list via YAML diffs")
+                .short_desc("Upsert a nested list of tasks")
                 .category("Todo")
-                .param_array("diffs", todo_diff_object(), true)
+                .param_array("items", todo_item_object(), true)
                 .build(),
         ]
     }

--- a/src/modules/questions/think.rs
+++ b/src/modules/questions/think.rs
@@ -124,13 +124,11 @@ pub(super) fn execute_todo(tool: &ToolUse, state: &mut State) -> ToolResult {
     };
 
     match apply_todo_upsert(items_val, state) {
-        Ok(annex) => {
-            let body = if annex.trim().is_empty() {
-                "Todo applied \u{2014} the task list is now empty.".to_owned()
-            } else {
-                format!("Todo applied. Current tasks:\n\n{}", annex.trim_end())
-            };
-            let mut result = ToolResult::new(tool.id.clone(), body, false);
+        Ok(recap) => {
+            // "Todo applied." sits OUTSIDE the tagged block deliberately: it is
+            // the durable confirmation the call succeeded, and it survives when
+            // the stripper later collapses this (by then superseded) recap.
+            let mut result = ToolResult::new(tool.id.clone(), format!("Todo applied.\n\n{recap}"), false);
             result.preserves_tempo = true; // FR8 — structural edits preserve tempo
             result
         }

--- a/src/modules/questions/think.rs
+++ b/src/modules/questions/think.rs
@@ -85,66 +85,45 @@ pub(super) fn execute(tool: &ToolUse, state: &mut State) -> ToolResult {
     result
 }
 
-/// Apply the `Todo` YAML diffs to the focused thread's tasks.
+/// Apply the `Todo` structured upsert to the focused thread's tasks.
 ///
 /// Resolves the focused thread from `FocusState`; rejects when none is focused
 /// (all task-tracking must live in a thread — design §5/§9-#7). Parses the
-/// `diffs` array (list of `{prev, new}`), applies them to the thread's virtual
-/// task YAML, reconciles by id, and returns either the fresh canonical YAML (on
-/// success) or an error string. On any change the Todo panel is **deprecated but
-/// tempo preserved** (FR8): `touch_panel` marks it stale so the fresh tree emits
-/// at tempo exhaustion, never forced immediately.
-fn apply_todo_diffs(diffs_val: &serde_json::Value, state: &mut State) -> Result<String, String> {
+/// `items` array, upserts it (validate-then-apply, atomic), and returns the
+/// refreshed task tree. On any change the Todo panel is **deprecated but tempo
+/// preserved** (FR8): `touch_panel` marks it stale so the fresh tree emits at
+/// tempo exhaustion, never forced immediately.
+fn apply_todo_upsert(items_val: &serde_json::Value, state: &mut State) -> Result<String, String> {
     let Some(tid) = cp_mod_threads::types::FocusState::get(state).focused_thread_id.clone() else {
         return Err("no focused thread (tasks must live in a thread; Read a thread first).".to_owned());
     };
-    let diffs = parse_diffs(diffs_val)?;
-    // Apply the edit (mutates the tasks); the returned canonical YAML is not
-    // shown in the result anymore — the Todo panel already renders it, so the
-    // tool result instead carries the synthetic task tree (T686).
-    let _yaml = cp_mod_todo::yaml::apply_diffs(state, &tid, &diffs)?;
+    let items = cp_mod_todo::upsert::parse_items(items_val)?;
+    let _created = cp_mod_todo::upsert::upsert(state, &tid, &items)?;
     // Deprecate the Todo panel but preserve tempo (FR8) — no forced refresh.
     state.touch_panel(crate::state::Kind::TODO);
     Ok(cp_mod_todo::tree::result_annex(state, &tid))
 }
 
-/// One parsed `{prev, new}` search/replace edit for the `Todo` tool.
-type TodoDiff = (String, String);
-
-/// Parse the `diffs` JSON array into `(prev, new)` string pairs. A missing
-/// `prev`/`new` defaults to the empty string (empty `prev` = append).
-fn parse_diffs(diffs_val: &serde_json::Value) -> Result<Vec<TodoDiff>, String> {
-    let arr = diffs_val.as_array().ok_or_else(|| "'diffs' must be an array".to_owned())?;
-    let mut out = Vec::with_capacity(arr.len());
-    for (idx, entry) in arr.iter().enumerate() {
-        let obj = entry.as_object().ok_or_else(|| format!("diff #{}: must be an object", idx.saturating_add(1)))?;
-        let prev = obj.get("prev").and_then(serde_json::Value::as_str).unwrap_or("").to_owned();
-        let new = obj.get("new").and_then(serde_json::Value::as_str).unwrap_or("").to_owned();
-        out.push((prev, new));
-    }
-    Ok(out)
-}
-
-/// Execute the `Todo` tool — apply `{prev, new}` YAML diffs to the focused
+/// Execute the `Todo` tool — upsert a nested list of tasks onto the focused
 /// thread's task tree.
 ///
-/// This is the single task-editing entry point. The model edits a **virtual,
-/// canonical YAML** projection of the tasks (the same text the Todo panel
-/// shows): each diff is a search/replace, `prev` matching exactly once. Adding a
-/// child = insert a `children:` sub-item; deleting = remove the lines
-/// (soft-cancel); reordering = move lines; renaming/status = edit the field.
-/// Rejects when no thread is focused — tasks are thread-owned (design §5/§9-#7).
+/// This is the single task-editing entry point. Each payload item carrying an
+/// `id` **updates** that task (only the fields present are touched); an item
+/// without one is **created**. Parenthood comes from physical nesting alone —
+/// an item's `children` are created under it, and a nested item may never carry
+/// an `id`. The call **merges**: tasks absent from the payload are untouched, so
+/// removal is an explicit `status: cancelled`, never an omission. Rejects when
+/// no thread is focused — tasks are thread-owned (design §5/§9-#7).
 ///
-/// On success the tool result echoes the **fresh canonical YAML** so the model
-/// (and user) always see the interpreted tree — the safety net that makes
-/// lenient indentation safe. Tempo-preserving (FR8): a structural edit
+/// On success the result echoes the refreshed task tree so the model (and user)
+/// always see the interpreted state. Tempo-preserving (FR8): a structural edit
 /// deprecates the Todo panel but never breaks tempo.
 pub(super) fn execute_todo(tool: &ToolUse, state: &mut State) -> ToolResult {
-    let Some(diffs_val) = tool.input.get("diffs") else {
-        return ToolResult::new(tool.id.clone(), "Todo: missing 'diffs' array.".to_owned(), true);
+    let Some(items_val) = tool.input.get("items") else {
+        return ToolResult::new(tool.id.clone(), "Todo: missing 'items' array.".to_owned(), true);
     };
 
-    match apply_todo_diffs(diffs_val, state) {
+    match apply_todo_upsert(items_val, state) {
         Ok(annex) => {
             let body = if annex.trim().is_empty() {
                 "Todo applied \u{2014} the task list is now empty.".to_owned()

--- a/yamls/tools/core.yaml
+++ b/yamls/tools/core.yaml
@@ -36,36 +36,43 @@ tools:
 
   Todo:
     description: |
-      Edit the CURRENTLY FOCUSED thread's task list. Tasks are thread-owned, so this is rejected when no thread is focused — Read a thread first.
+      Upsert tasks on the CURRENTLY FOCUSED thread. Tasks are thread-owned, so this is rejected when no thread is focused — Read a thread first.
 
-      The task list is a virtual YAML document (also shown in the Todo panel). You edit it with `diffs`: an ordered list of `{prev, new}` search/replace edits — the SAME paradigm as the Edit tool's `old_string`/`new_string`. Each `prev` must match the current YAML EXACTLY ONCE; an empty `prev` appends `new` at the end. Diffs apply in order (a later diff sees earlier results). The whole call is ATOMIC: if any `prev` fails to match, NOTHING is applied. After applying, the tool echoes the fresh task tree — always check it to confirm the interpreted result.
+      You pass `items`: a list of tasks. Each one either UPDATES an existing task (it carries an `id`) or CREATES a new one (it does not). Nesting is how you express parenthood — there is no parent_id anywhere.
 
-      The YAML shape — each item's FIRST line is `- {id}: {status}` (the id is the mapping KEY, its value is the status), with `title`/`description`/`children` as sibling keys:
+        {"items": [
+          {"id": "X41", "status": "done"},
+          {"title": "Ship feature Y", "status": "in_progress",
+           "children": [
+             {"title": "Write the code"},
+             {"title": "Write the tests"}
+           ]}
+        ]}
 
-        - X41: in_progress
-          title: Ship feature X
-          description: |
-            Longer detail, if any.
-          children:
-            - X42: planned
-              title: Write code
+      Fields per item:
+      - `id` — existing task to update. OMIT IT TO CREATE. Ids are backend-assigned; never invent one.
+      - `title` — required when creating. On an update, omit it to leave the title untouched.
+      - `description` — longer detail. Omit to leave untouched.
+      - `status` — one of: planned, in_progress, done, cancelled. Defaults to planned on create.
+      - `children` — a nested list of tasks CREATED under this item.
 
-      PREFER SMALL, INLINE, ID-ANCHORED EDITS. Because the id opens each line, a status flip is a tiny self-anchoring edit that needs no surrounding context — this is the MOST ROBUST way to edit:
+      THE CALL MERGES — it never replaces. Tasks you don't mention are left exactly as they are, so you only ever send what actually changed. A status flip is one tiny item:
 
-        {"prev": "X42: planned", "new": "X42: done"}
+        {"items": [{"id": "X42", "status": "done"}]}
 
-      Anchor every `prev` on the `{id}: {status}` line (or a single `title:`/`description:` line), NOT on copied multi-line blocks — small anchored edits never break on indentation or neighbouring lines.
+      NESTED ITEMS ARE CREATION-ONLY. A child may never carry an `id`: its position in the payload is what sets its parent. To add subtasks to an existing task, write the parent with its `id` and put the new (id-less) children under it:
 
-      IMPORTANT — the Todo panel may be STALE. The panel (and any tree you were shown earlier) can lag the live state. Do NOT copy long stretches of it verbatim into `prev`. Anchor on the id line, keep edits tiny, and read the echoed tree after each call to see the true current state.
+        {"items": [{"id": "X41", "children": [{"title": "Late-discovered subtask"}]}]}
 
-      Rules:
-      - CREATE an item by writing a new block and OMITTING its `{id}: {status}` line — instead give `title` (required) and optionally `status:` (defaults to planned). The backend assigns the next id and echoes it back.
-      - UPDATE an item's status with the tiny inline edit `{"prev":"X41: in_progress","new":"X41: done"}`. Update its title/description by editing that field line.
-      - REPARENT / NEST by moving an item's block under another item's `children:` list.
-      - REORDER siblings by moving their blocks — sibling order is positional (top to bottom).
-      - DELETE an item by removing its block: it is SOFT-CANCELLED (recoverable, sorted last in its group), never hard-deleted.
-      - `status` is one of: planned, in_progress, done, cancelled.
+      DELETING is an explicit `{"id": "X41", "status": "cancelled"}` — a cancelled task is soft-deleted (hidden, recoverable, sorted last), never hard-removed. Omitting a task NEVER deletes it.
+
+      The whole call is ATOMIC and validated first: a nested `id`, an `id` that doesn't exist on this thread, a repeated `id`, a create with no `title`, or a bad `status` rejects the ENTIRE call and changes nothing — the error names every problem at once. After applying, the tool echoes the fresh task tree; check it to confirm the interpreted result.
+
+      Reparenting and reordering existing tasks are not supported — create the task where you want it.
     parameters:
-      diffs: "Ordered list of {prev, new} search/replace edits applied to the task YAML."
-      prev: "Exact text to find in the current task YAML (matches exactly once; empty appends 'new' at the end). Prefer a tiny id-anchored anchor like 'X41: in_progress'."
-      new: "Replacement text."
+      items: "List of tasks to create or update. An item with `id` updates it; an item without `id` creates it. Nested `children` are always created under their parent."
+      id: "Existing task id to UPDATE (e.g. 'X41'). Omit to CREATE. Never allowed on a nested child."
+      title: "Task title. Required when creating; omit to leave untouched."
+      description: "Longer detail. Omit to leave untouched."
+      status: "One of: planned, in_progress, done, cancelled. Defaults to planned on create."
+      children: "Nested tasks CREATED under this one. Same fields as a parent item, minus `id` (nesting sets the parent)."

--- a/yamls/tools/threads.yaml
+++ b/yamls/tools/threads.yaml
@@ -7,6 +7,20 @@ tools:
       focus is cleared, starting a dangling phase of 5 tool calls before the AI
       must focus on another MY_TURN thread.
 
+      WRITING STYLE (read before composing any reply):
+      Je passe mes journées à lire des réponses d'agents LLM, verbeuses, lourdes et illisibles.
+      Ne fais pas ça. Réduis au minimum la charge cognitive de tes messages : réponds à ma
+      question, et donne-moi uniquement l'information dont j'ai besoin, de façon synthétique.
+      Écris en français ou en anglais courant, sans charabia ni fioritures.
+
+      Concrètement :
+      - Si la question est fermée, la première phrase est la réponse. Souvent elle suffit.
+      - N'ajoute ni contexte, ni mises en garde, ni « points à surveiller », ni suites possibles.
+        Si tu juges un élément indispensable, une ligne maximum, à la fin.
+      - Ne détaille pas ta démarche ni tes vérifications, sauf si je les demande.
+      - Pas de listes ni de titres pour une réponse tenant en trois phrases.
+      - Pas de métaphores, pas d'emphase, pas de formules d'accroche.
+
       PREFER RICH PRESENTATIONS OVER PLAIN PROSE:
       A message is not limited to text. Two embeddable widgets — file cards
       (```file-upload```) and interactive forms (```form```) — make your replies


### PR DESCRIPTION
Reuses a branch whose original PR (#193, T715) is already merged; these are the 8 commits since master.

## Todo tool: YAML diffs → structured upsert

The `{prev, new}` YAML search/replace surface was error-prone to drive blind — a stale panel or a mis-copied indent silently failed the match. Replaced with a structured `items` list: an item carrying an `id` updates, one without creates, and parenthood is expressed **only** by physical nesting (`children`), so `parent_id` disappears from the surface entirely.

Two deliberate semantics:

- **Merge, never replace.** Tasks absent from the payload are untouched, so removal is an explicit `status: cancelled` rather than an omission — a partial call can't silently wipe the roadmap.
- **Validate-then-apply.** Every problem in the payload is collected before anything mutates, so a bad call is atomic and names all its errors at once.

Reparenting and reordering existing tasks are gone. They were the bug source and have no meaning in a pure upsert.

## Task recaps: one producer, one live copy

`tree::result_annex` is now the single producer of a complete recap block (header + tree + multi-in-progress-leaf warning). Both call sites — the `Todo` tool result and the annex appended when a `task_id` flips a task — splice exactly that string, so they cannot drift.

Each block is framed by `<!--TODO_RECAP-->` / `<!--/TODO_RECAP-->` sentinels defined beside the producer and imported by the reader. Regex over the tree's box-drawing glyphs was rejected: a task title can legitimately contain `└──`.

`recap::strip_superseded` then collapses every recap but the most recent into a one-line stub, leaving exactly ONE task tree in context so the model can't mistake a stale snapshot for current state. The stub carries no sentinel, making the pass idempotent by construction; an unterminated block stops the scan rather than deleting to end-of-string.

**Gating is load-bearing, not decorative.** Rewriting old messages mutates the conversation prefix and invalidates the LLM prompt cache from the earliest edited message onward. The pass therefore runs only when the queue is idle (no half-formed batch) AND tempo is already broken — on a tempo-preserving tick that cost would be gratuitous; on a tempo-breaking tick the cache is dropped anyway and the strip rides along free.

**It edits the source of truth.** The strip returns the positions of the messages it rewrote and the caller re-persists them, so memory and disk never disagree and each recap is collapsed exactly once in its lifetime instead of re-collapsed after every reload. Only `content` (what the model reads) is rewritten, never `display` (what the TUI renders), so human scrollback stays intact.

## Also included

- `Send` tool description carries an explicit low-verbosity writing directive.
- Fixes a ~6-month-old mislabel where a plain `console_easy_bash` timeout reported "Callback result unavailable". Root cause: pre-flight warnings appended after the bare blocking sentinel tipped the result into the callback branch. Both the matching and force-resolve phases now discriminate on the `cb_block_` id prefix, and the console path re-appends the stripped warnings so they survive.

## Verification

9/9 recap tests green, including four end-to-end over a real `State` (strips all but the last across message boundaries, leaves a lone recap alone, idempotent across repeated passes, never rewrites `display`). Workspace clippy, fmt, api-contract and structure checks all pass. Deployed and exercised live — persistence confirmed by 18 stubbed messages surviving a reload.
